### PR TITLE
Bootstrap CMake + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        build_type: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lukka/setup-cmake@v1
+      - name: Cache vcpkg
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/vcpkg
+            ${{ github.workspace }}/build/vcpkg_installed
+          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+          restore-keys: ${{ runner.os }}-vcpkg-
+      - name: Configure
+        run: cmake --preset ${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}
+      - name: Build
+        run: cmake --build --preset ${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}
+      - name: Test
+        run: ctest --preset ${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}
+      - name: Upload executable
+        if: matrix.build_type == 'Release'
+        uses: actions/upload-artifact@v3
+        with:
+          name: PrometheanEngine-${{ runner.os }}
+          path: build/${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}/src/promethean-engine${{ matrix.os == 'windows-latest' && '.exe' || '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.25)
+project(PrometheanEngine VERSION 0.1 LANGUAGES CXX)
+
+# Enable C++20 and warnings
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(DEFINED ENV{VCPKG_ROOT})
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
+endif()
+
+add_subdirectory(src)
+
+enable_testing()
+add_subdirectory(tests)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,86 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "windows",
+      "displayName": "Windows Release",
+      "inherits": "release",
+      "binaryDir": "${sourceDir}/build/windows",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Windows"
+      }
+    },
+    {
+      "name": "macos",
+      "displayName": "macOS Release",
+      "inherits": "release",
+      "binaryDir": "${sourceDir}/build/macos",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Darwin"
+      }
+    },
+    {
+      "name": "android",
+      "displayName": "Android Release",
+      "inherits": "release",
+      "binaryDir": "${sourceDir}/build/android",
+      "toolchainFile": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake",
+      "cacheVariables": {
+        "CMAKE_ANDROID_ARCH_ABI": "arm64-v8a",
+        "ANDROID_PLATFORM": "android-21"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "windows",
+      "configurePreset": "windows"
+    },
+    {
+      "name": "macos",
+      "configurePreset": "macos"
+    },
+    {
+      "name": "android",
+      "configurePreset": "android"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "output": { "outputOnFailure": true }
+    }
+  ]
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(promethean-engine main.cpp)
+
+# Warnings as errors
+if(MSVC)
+    target_compile_options(promethean-engine PRIVATE /W4 /WX)
+else()
+    target_compile_options(promethean-engine PRIVATE -Wall -Wextra -pedantic -Werror)
+endif()
+
+set_target_properties(promethean-engine PROPERTIES
+    OUTPUT_NAME "promethean-engine"
+)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(GTest CONFIG REQUIRED)
+add_executable(dummy_test test_dummy.cpp)
+target_link_libraries(dummy_test PRIVATE GTest::gtest_main)
+add_test(NAME dummy_test COMMAND dummy_test)

--- a/tests/test_dummy.cpp
+++ b/tests/test_dummy.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+TEST(DummyTest, AlwaysPasses) {
+    EXPECT_EQ(1, 1);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "promethean-engine",
+  "version-string": "0.1.0",
+  "dependencies": [
+    "fmt",
+    "spdlog",
+    "sdl3",
+    "glad",
+    "gtest"
+  ]
+}


### PR DESCRIPTION
## Summary
- add minimal CMake project and presets
- manage dependencies with vcpkg
- add dummy main and test
- setup GitHub Actions workflow

## Testing
- `cmake --preset debug` *(fails: Could not find GTestConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68501ff0a850832487b891e4aeae295d