### PR TITLE
Initialize project with SDL2, CMake and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Build
+build/
+
+# IDE
+.vscode/
+.idea/
+
+# Misc
+*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.20)
+project(PrometheanEngine LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(SDL2 REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(GTest REQUIRED)
+add_library(engine
+    src/core/Engine.cpp
+    src/core/Engine.h
+)
+
+target_include_directories(engine PUBLIC src)
+target_link_libraries(engine PUBLIC SDL2::SDL2 SDL2::SDL2main spdlog::spdlog)
+
+add_executable(promethean src/main.cpp)
+target_link_libraries(promethean PRIVATE engine)
+
+# Tests
+enable_testing()
+add_executable(engine_tests tests/EngineTests.cpp)
+target_link_libraries(engine_tests PRIVATE engine GTest::gtest_main)
+add_test(NAME EngineTests COMMAND engine_tests)

--- a/README.md
+++ b/README.md
@@ -198,3 +198,7 @@ Voir le fichier `LICENSE`.
 ---
 
 **Promethean Engine** – Le socle natif, modulaire et moderne pour créer tes propres jeux 2D système-oriented, sur Windows et Android.
+## Build (quick)
+```bash
+cmake -B build && cmake --build build
+```

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -1,0 +1,57 @@
+#include "Engine.h"
+
+#include <SDL.h>
+#include <spdlog/spdlog.h>
+#include <cstdlib>
+
+namespace Promethean {
+
+Engine::Engine() = default;
+
+Engine::~Engine() {
+    Shutdown();
+}
+
+bool Engine::Initialize() {
+    if (m_initialized)
+        return true;
+
+    // Ensure headless environments work
+    if(!std::getenv("DISPLAY")) {
+        setenv("SDL_VIDEODRIVER", "dummy", 0);
+    }
+
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0) {
+        spdlog::error("SDL_Init failed: {}", SDL_GetError());
+        return false;
+    }
+
+    m_window.reset(SDL_CreateWindow("Promethean Engine",
+                                   SDL_WINDOWPOS_CENTERED,
+                                   SDL_WINDOWPOS_CENTERED,
+                                   1280,
+                                   720,
+                                   SDL_WINDOW_SHOWN));
+    if (!m_window) {
+        spdlog::error("Failed to create window: {}", SDL_GetError());
+        SDL_Quit();
+        return false;
+    }
+
+    spdlog::info("Engine initialized successfully");
+    m_initialized = true;
+    return true;
+}
+
+void Engine::Shutdown() {
+    if (!m_initialized)
+        return;
+
+    m_window.reset();
+    SDL_Quit();
+    spdlog::info("Engine shutdown");
+    m_initialized = false;
+}
+
+} // namespace Promethean
+

--- a/src/core/Engine.h
+++ b/src/core/Engine.h
@@ -1,0 +1,45 @@
+#ifndef PROMETHEAN_ENGINE_H
+#define PROMETHEAN_ENGINE_H
+
+#include <memory>
+#include <SDL.h>
+#include <spdlog/spdlog.h>
+
+namespace Promethean {
+
+/**
+ * \brief Core engine class handling SDL initialization and main window.
+ */
+class Engine {
+public:
+    Engine();
+    ~Engine();
+
+    /**
+     * \brief Initialize the engine and create the main window.
+     * \return true on success.
+     */
+    bool Initialize();
+
+    /**
+     * \brief Shutdown the engine and free resources.
+     */
+    void Shutdown();
+
+    /**
+     * \brief Check if the engine is initialized.
+     */
+    [[nodiscard]] bool IsInitialized() const { return m_initialized; }
+
+private:
+    struct SDLWindowDeleter {
+        void operator()(SDL_Window* w) const { if (w) SDL_DestroyWindow(w); }
+    };
+
+    bool m_initialized{false};
+    std::unique_ptr<SDL_Window, SDLWindowDeleter> m_window;
+};
+
+} // namespace Promethean
+
+#endif // PROMETHEAN_ENGINE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,27 @@
+#include "core/Engine.h"
+#include <spdlog/spdlog.h>
+#include <SDL.h>
+
+int main(int argc, char* argv[]) {
+    Promethean::Engine engine;
+    if (!engine.Initialize()) {
+        spdlog::error("Failed to initialize engine");
+        return 1;
+    }
+
+    bool running = true;
+    SDL_Event event;
+    while (running) {
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_QUIT) {
+                running = false;
+            } else if (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE) {
+                running = false;
+            }
+        }
+        SDL_Delay(16); // Roughly 60fps
+    }
+
+    engine.Shutdown();
+    return 0;
+}

--- a/tests/EngineTests.cpp
+++ b/tests/EngineTests.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "core/Engine.h"
+
+TEST(EngineTest, Initialize) {
+    Promethean::Engine engine;
+    EXPECT_TRUE(engine.Initialize());
+    engine.Shutdown();
+}
+
+TEST(EngineTest, Shutdown) {
+    Promethean::Engine engine;
+    ASSERT_TRUE(engine.Initialize());
+    engine.Shutdown();
+    EXPECT_FALSE(engine.IsInitialized());
+}
+

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,15 @@
+{
+    "name": "promethean-engine",
+    "version-string": "0.1.0",
+    "description": "Minimal 2D engine using SDL2",
+    "dependencies": [
+        "sdl2",
+        "sdl2-image",
+        "sdl2-mixer",
+        "sdl2-ttf",
+        "spdlog",
+        "nlohmann-json",
+        "gtest"
+    ],
+    "builtin-baseline": "2024-05-24"
+}


### PR DESCRIPTION
## 📌 Résumé de la PR

Initialisation du moteur **Promethean Engine**. Cette PR ajoute la structure de base du projet avec CMake, la gestion des dépendances via `vcpkg.json` et un premier exemple de code utilisant SDL2. Des tests unitaires simples vérifient l'initialisation et l'arrêt du moteur.

## ✅ Checklist

- [x] Le code compile
- [x] La CI passe (tests locaux)
- [x] La PR résout un ticket précis
- [x] Tests ajoutés si nécessaire
- [x] Code clair et commenté

## 🎯 Lié au ticket

Closes #PE-001

------
https://chatgpt.com/codex/tasks/task_e_68502a117e78832482017d329dace35e