### PR TITLE
Fix invalid vcpkg baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,5 @@
         "spdlog",
         "nlohmann-json",
         "gtest"
-    ],
-    "builtin-baseline": "2024-05-24"
+    ]
 }


### PR DESCRIPTION
## Summary
- remove invalid builtin-baseline entry from `vcpkg.json`

## Testing
- `cmake -B build && cmake --build build` *(fails: Could not find SDL2)*
- `ctest --output-on-failure` *(fails: No tests were found)*
- `vcpkg install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502ef42f7c8324afd6b2da141bf295