### PR TITLE
Fix Ubuntu build dependencies for vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,19 @@ jobs:
           fi
         shell: bash
 
+      # 6.5. Install Linux build dependencies
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            libtool \
+            pkg-config \
+            build-essential
+        shell: bash
+
       # 7. Bootstrap vcpkg si nécessaire
       - name: Bootstrap vcpkg
         if: steps.check_vcpkg.outputs.vcpkg_exists == 'true'


### PR DESCRIPTION
## Summary
- install Linux build packages before bootstrapping vcpkg

## Testing
- `cmake .. && cmake --build . -j $(nproc) && ctest --output-on-failure` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_6850338aecb88324acbab1757cad1179