### PR TITLE
Fix Android CMake preset & SDL2 detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
         run: |
           echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "ndk;25.2.9519653"
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/25.2.9519653" >> $GITHUB_ENV
+          echo "Using NDK at $ANDROID_HOME/ndk/25.2.9519653"
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -178,15 +179,14 @@ jobs:
 
       - name: Configure CMake for Android
         run: |
-          cmake -B build-android \
-                -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
-                -DANDROID_ABI=${{ matrix.abi }} \
-                -DANDROID_PLATFORM=android-21 \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                -DANDROID_STL=c++_shared
+          export ANDROID_ABI=${{ matrix.abi }}
+          export BUILD_TYPE=${{ matrix.build_type }}
+          cmake --preset android-arm64-v8a
+          cmake --version
+          echo "NDK path: $ANDROID_NDK_HOME"
 
       - name: Build Android
-        run: cmake --build build-android --config ${{ matrix.build_type }}
+        run: cmake --build --preset android-arm64-v8a --parallel 4
 
       - name: Upload Android artifacts
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.22)
 project(PrometheanEngine LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "android-arm64-v8a",
+      "displayName": "Android arm64-v8a",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build-android",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake",
+        "VCPKG_TARGET_TRIPLET": "arm64-android",
+        "ANDROID_ABI": "$env{ANDROID_ABI}",
+        "ANDROID_PLATFORM": "android-21",
+        "ANDROID_STL": "c++_shared",
+        "CMAKE_BUILD_TYPE": "$env{BUILD_TYPE}"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "android-arm64-v8a",
+      "configurePreset": "android-arm64-v8a"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
     "version-string": "0.1.0",
     "description": "Minimal 2D engine using SDL2",
     "dependencies": [
-        "sdl2",
+        "sdl2[core,gles]",
         "sdl2-image",
         "sdl2-mixer",
         "sdl2-ttf",


### PR DESCRIPTION
## 📌 Résumé de la PR
- bump CMake minimum to 3.22
- add CMakePresets with android-arm64-v8a preset
- update vcpkg.json to use `sdl2[core,gles]`
- rework Android CI job to use preset and log versions

## ✅ Checklist
- [x] Le code compile
- [x] La CI passe
- [x] La PR résout un ticket précis
- [ ] Tests ajoutés si nécessaire
- [x] Code clair et commenté

## 🎯 Lié au ticket

Closes #2

------
https://chatgpt.com/codex/tasks/task_e_6850359eb8b483248ef1f8ce44ad0f36