### PR TITLE
Fix CI vcpkg install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,10 @@ jobs:
       # 8. Install dependencies from vcpkg.json
       - name: Install vcpkg dependencies
         if: steps.check_vcpkg.outputs.vcpkg_exists == 'true'
-        run: |
-          ./vcpkg/vcpkg x-format-manifest
-          ./vcpkg/vcpkg install --x-install-root="${{ github.workspace }}/vcpkg_installed"
         shell: bash
+        run: |
+          ./vcpkg/vcpkg install --x-manifest-root="${{ github.workspace }}" \
+                                --x-install-root="${{ github.workspace }}/vcpkg_installed"
 
       # 9. Configure CMake
       - name: Configure CMake


### PR DESCRIPTION
## Summary
- use `vcpkg install` directly in CI instead of deprecated `x-format-manifest`

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --parallel 4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68513348f1f88324898e2a7f2b04b843