### PR TITLE
Fix vcpkg manifest and Android workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,14 @@ jobs:
         with:
           cmake-version: '3.28.x'
 
-      # 3. Setup Ninja (Linux/macOS)
+      # 3. Setup Ninja
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@v5
+        if: runner.os == 'Windows'
+
+      - name: Install Ninja (Linux/macOS)
         if: runner.os != 'Windows'
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
 
       # 4. Setup MSVC sur Windows
       - name: Setup MSVC Dev Environment
@@ -170,6 +174,18 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/25.2.9519653" >> $GITHUB_ENV
           echo "Using NDK at $ANDROID_HOME/ndk/25.2.9519653"
 
+      - name: Bootstrap vcpkg
+        run: |
+          if [ ! -d "vcpkg" ]; then
+            git clone https://github.com/Microsoft/vcpkg.git
+          fi
+          ./vcpkg/bootstrap-vcpkg.sh
+
+      - name: Install vcpkg dependencies
+        run: |
+          ./vcpkg/vcpkg install --x-manifest-root="${{ github.workspace }}" \
+                                --x-install-root="${{ github.workspace }}/vcpkg_installed"
+
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -182,7 +198,10 @@ jobs:
         run: |
           export ANDROID_ABI=${{ matrix.abi }}
           export BUILD_TYPE=${{ matrix.build_type }}
-          cmake --preset android-arm64-v8a
+          cmake --preset android-arm64-v8a \
+            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++
           cmake --version
           echo "NDK path: $ANDROID_NDK_HOME"
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,20 +2,20 @@
   "name": "promethean-engine",
   "version-string": "0.1.0",
   "description": "Minimal 2D engine using SDL2",
+  "builtin-baseline": "16c71a39e5a0fc0bdb3fad03beef8f38ee00ee3b",
   "dependencies": [
+    "gtest",
+    "nlohmann-json",
     {
       "name": "sdl2",
+      "default-features": false,
       "features": [
-        "core",
         "gles"
       ]
     },
     "sdl2-image",
     "sdl2-mixer",
     "sdl2-ttf",
-    "spdlog",
-    "nlohmann-json",
-    "gtest"
-  ],
-  "builtin-baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
+    "spdlog"
+  ]
 }


### PR DESCRIPTION
## Summary
- fix vcpkg manifest for SDL2 gles build
- install ninja on Linux/macOS
- bootstrap vcpkg for Android before configuring
- pass toolchain and compiler to Android CMake configure

## Testing
- `cmake -S . -B build` *(fails: SDL2Config.cmake not found)*
- `cmake --build build` *(fails: no Makefile)*
- `ctest --output-on-failure -j 4` *(no tests were found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68513a55165c8324b3fd6d0066424f3b