### PR TITLE
Implement LogSystem singleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ add_library(engine
     # Core
     src/core/Engine.cpp
     src/core/Engine.h
+    src/core/LogSystem.cpp
+    src/core/LogSystem.h
 )
 
 # Alias pour usage externe
@@ -91,11 +93,15 @@ else()
 endif()
 
 # Configuration Debug/Release
-target_compile_definitions(engine 
+target_compile_definitions(engine
     PRIVATE
         $<$<CONFIG:Debug>:PROMETHEAN_DEBUG>
         $<$<CONFIG:Release>:PROMETHEAN_RELEASE>
 )
+
+if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
+    target_compile_definitions(engine PUBLIC TESTING)
+endif()
 
 # === CONFIGURATION ANDROID SPÉCIFIQUE ===
 if(ANDROID)
@@ -156,15 +162,17 @@ endif()
 
 # === TESTS UNITAIRES ===
 if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
-    add_executable(engine_tests 
+    add_executable(engine_tests
         tests/EngineTests.cpp
+        tests/core/TestLogSystem.cpp
     )
     
-    target_link_libraries(engine_tests 
-        PRIVATE 
+    target_link_libraries(engine_tests
+        PRIVATE
             Promethean::Engine
             GTest::gtest_main
     )
+    target_compile_definitions(engine_tests PRIVATE TESTING)
     
     # Configuration des tests
     set_target_properties(engine_tests PROPERTIES

--- a/src/core/LogSystem.cpp
+++ b/src/core/LogSystem.cpp
@@ -1,0 +1,76 @@
+#include "core/LogSystem.h"
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+struct LogSystem::Impl {
+    std::shared_ptr<spdlog::logger> logger;
+    Level currentLevel{Level::Info};
+};
+
+static spdlog::level::level_enum ToSpd(LogSystem::Level lvl)
+{
+    switch(lvl) {
+    case LogSystem::Level::Debug: return spdlog::level::debug;
+    case LogSystem::Level::Info:  return spdlog::level::info;
+    case LogSystem::Level::Warn:  return spdlog::level::warn;
+    case LogSystem::Level::Error: return spdlog::level::err;
+    }
+    return spdlog::level::info;
+}
+
+LogSystem& LogSystem::Instance()
+{
+    static LogSystem instance;
+    return instance;
+}
+
+LogSystem::LogSystem() : m_impl(std::make_unique<Impl>())
+{
+    auto sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    m_impl->logger = std::make_shared<spdlog::logger>("Promethean", std::move(sink));
+    m_impl->logger->set_pattern("[%Y-%m-%d %H:%M:%S.%f] [%^%l%$] %v");
+    m_impl->logger->set_level(spdlog::level::info);
+    spdlog::register_logger(m_impl->logger);
+}
+
+LogSystem::~LogSystem()
+{
+    Flush();
+    spdlog::drop("Promethean");
+}
+
+spdlog::logger& LogSystem::GetLogger()
+{
+    return *m_impl->logger;
+}
+
+const spdlog::logger& LogSystem::GetLogger() const
+{
+    return *m_impl->logger;
+}
+
+void LogSystem::SetLevel(Level level)
+{
+    m_impl->currentLevel = level;
+    m_impl->logger->set_level(ToSpd(level));
+}
+
+LogSystem::Level LogSystem::GetLevel() const
+{
+    return m_impl->currentLevel;
+}
+
+void LogSystem::Flush()
+{
+    m_impl->logger->flush();
+}
+
+#ifdef TESTING
+void LogSystem::SetCustomSinkForTesting(std::shared_ptr<spdlog::sinks::sink> sink)
+{
+    m_impl->logger->sinks().clear();
+    m_impl->logger->sinks().push_back(std::move(sink));
+}
+#endif
+

--- a/src/core/LogSystem.h
+++ b/src/core/LogSystem.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <memory>
+#include <string_view>
+#include <spdlog/logger.h>
+
+namespace spdlog {
+namespace sinks { class sink; }
+}
+
+/**
+ * @brief Global logging facility (thread-safe).
+ *
+ * Wrapper around spdlog; keeps a single sink to stdout with color.
+ */
+class LogSystem
+{
+public:
+    enum class Level { Debug, Info, Warn, Error };
+
+    /** Return the singleton instance (constructed on first call). */
+    static LogSystem& Instance();
+
+    /** Configure minimum severity displayed at runtime. */
+    void SetLevel(Level level);
+
+    /** Log helpers */
+    template<class... Args>
+    void Debug(std::string_view fmt, Args&&... args);
+    template<class... Args>
+    void Info (std::string_view fmt, Args&&... args);
+    template<class... Args>
+    void Warn (std::string_view fmt, Args&&... args);
+    template<class... Args>
+    void Error(std::string_view fmt, Args&&... args);
+
+    /** Flush all sinks (called during shutdown). */
+    void Flush();
+
+    /** Return current severity level. */
+    [[nodiscard]] Level GetLevel() const;
+
+#ifdef TESTING
+    /** Replace logger sink (testing only). */
+    void SetCustomSinkForTesting(std::shared_ptr<spdlog::sinks::sink> sink);
+#endif
+
+private:
+    LogSystem();                      // hidden
+    ~LogSystem();                     // flush + drop sink
+    LogSystem(const LogSystem&) = delete;
+    LogSystem& operator=(const LogSystem&) = delete;
+
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;     ///< PIMPL – contains spdlog::logger
+
+    spdlog::logger& GetLogger();
+    const spdlog::logger& GetLogger() const;
+};
+
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/ostr.h>
+
+// Template definitions
+
+template<class... Args>
+inline void LogSystem::Debug(std::string_view fmt, Args&&... args)
+{
+    auto& lg = GetLogger();
+    if (lg.should_log(spdlog::level::debug))
+        lg.debug(fmt, std::forward<Args>(args)...);
+}
+
+template<class... Args>
+inline void LogSystem::Info(std::string_view fmt, Args&&... args)
+{
+    auto& lg = GetLogger();
+    if (lg.should_log(spdlog::level::info))
+        lg.info(fmt, std::forward<Args>(args)...);
+}
+
+template<class... Args>
+inline void LogSystem::Warn(std::string_view fmt, Args&&... args)
+{
+    auto& lg = GetLogger();
+    if (lg.should_log(spdlog::level::warn))
+        lg.warn(fmt, std::forward<Args>(args)...);
+}
+
+template<class... Args>
+inline void LogSystem::Error(std::string_view fmt, Args&&... args)
+{
+    auto& lg = GetLogger();
+    if (lg.should_log(spdlog::level::err))
+        lg.error(fmt, std::forward<Args>(args)...);
+}
+

--- a/tests/core/TestLogSystem.cpp
+++ b/tests/core/TestLogSystem.cpp
@@ -1,0 +1,61 @@
+#include "core/LogSystem.h"
+#include <gtest/gtest.h>
+#include <spdlog/sinks/base_sink.h>
+#include <mutex>
+
+class CollectSink : public spdlog::sinks::base_sink<std::mutex>
+{
+public:
+    std::vector<std::string> messages;
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        spdlog::memory_buf_t buf;
+        base_sink<std::mutex>::formatter_->format(msg, buf);
+        messages.emplace_back(buf.begin(), buf.end());
+    }
+
+    void flush_() override { messages.clear(); }
+};
+
+TEST(LogSystem, SetLevel) {
+    auto& log = LogSystem::Instance();
+    log.SetLevel(LogSystem::Level::Debug);
+    EXPECT_EQ(log.GetLevel(), LogSystem::Level::Debug);
+}
+
+TEST(LogSystem, DebugBelowThreshold) {
+    auto& log = LogSystem::Instance();
+    auto mem_sink = std::make_shared<CollectSink>();
+    log.SetCustomSinkForTesting(mem_sink);
+    log.SetLevel(LogSystem::Level::Info);
+    log.Debug("hidden message");
+    EXPECT_TRUE(mem_sink->messages.empty());
+}
+
+TEST(LogSystem, ErrorAlwaysPrinted) {
+    auto& log = LogSystem::Instance();
+    auto mem_sink = std::make_shared<CollectSink>();
+    log.SetCustomSinkForTesting(mem_sink);
+    log.SetLevel(LogSystem::Level::Warn);
+    log.Error("critical failure");
+    ASSERT_FALSE(mem_sink->messages.empty());
+    EXPECT_NE(mem_sink->messages.front().find("[error]"), std::string::npos);
+}
+
+TEST(LogSystem, Flush) {
+    auto& log = LogSystem::Instance();
+    auto mem_sink = std::make_shared<CollectSink>();
+    log.SetCustomSinkForTesting(mem_sink);
+    log.SetLevel(LogSystem::Level::Info);
+    log.Info("hello");
+    log.Flush();
+    EXPECT_TRUE(mem_sink->messages.empty());
+}
+
+TEST(LogSystem, Singleton) {
+    auto& log1 = LogSystem::Instance();
+    auto& log2 = LogSystem::Instance();
+    EXPECT_EQ(&log1, &log2);
+}


### PR DESCRIPTION
## Summary
- add `LogSystem` singleton based on spdlog with colorized output
- expose helper to swap sinks when TESTING is defined
- hook new logger into build and add unit tests

## Testing
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6852dc3186288324a6e7c38b6478781a