### PR TITLE
Implement thread-safe EventBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ add_library(engine
     src/core/Engine.h
     src/core/LogSystem.cpp
     src/core/LogSystem.h
+    src/core/EventBus.cpp
+    src/core/EventBus.h
 )
 
 # Alias pour usage externe
@@ -165,6 +167,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
     add_executable(engine_tests
         tests/EngineTests.cpp
         tests/core/TestLogSystem.cpp
+        tests/core/TestEventBus.cpp
     )
     
     target_link_libraries(engine_tests

--- a/src/core/EventBus.cpp
+++ b/src/core/EventBus.cpp
@@ -1,0 +1,24 @@
+#include "core/EventBus.h"
+
+EventBus& EventBus::Instance()
+{
+    static EventBus instance;
+    return instance;
+}
+
+void EventBus::Unsubscribe(size_t id)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    for (auto& [type, vec] : m_subs)
+    {
+        auto it = std::find_if(vec.begin(), vec.end(), [&](const Subscription& s) { return s.id == id; });
+        if (it != vec.end())
+        {
+            vec.erase(it);
+            LogSystem::Instance().Debug("Unsubscribed handler {}", id);
+            return;
+        }
+    }
+    LogSystem::Instance().Warn("Attempted to unsubscribe unknown id {}", id);
+}
+

--- a/src/core/EventBus.h
+++ b/src/core/EventBus.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "core/LogSystem.h"
+#include <any>
+#include <functional>
+#include <unordered_map>
+#include <mutex>
+#include <typeindex>
+#include <vector>
+#include <algorithm>
+
+/**
+ * @brief Global publish/subscribe event bus (thread-safe, non-blocking).
+ *
+ * Events are plain structs passed by const reference inside std::any.
+ */
+class EventBus
+{
+public:
+    /// Singleton accessor
+    static EventBus& Instance();
+
+    /** Type alias for a generic handler */
+    using Handler = std::function<void(const std::any&)>;
+
+    /**
+     * @brief Subscribe to all events of type T.
+     * @tparam T  Plain struct representing the event
+     * @param handler Callback executed on publication (executed synchronously).
+     * @return subscription id; retain if you want to unsubscribe later.
+     */
+    template<class T>
+    size_t Subscribe(Handler handler);
+
+    /**
+     * @brief Unsubscribe via id returned by Subscribe.
+     */
+    void Unsubscribe(size_t id);
+
+    /**
+     * @brief Publish an event of type T (synchronous).
+     */
+    template<class T>
+    void Publish(const T& event);
+
+    /** Disable copy */
+    EventBus(const EventBus&) = delete;
+    EventBus& operator=(const EventBus&) = delete;
+
+private:
+    EventBus() = default;
+    ~EventBus() = default;
+
+    struct Subscription {
+        size_t id;
+        Handler handler;
+    };
+
+    std::unordered_map<std::type_index, std::vector<Subscription>> m_subs;
+    std::mutex m_mutex;
+    size_t m_nextId{0};
+};
+
+// ===== Template definitions =====
+
+template<class T>
+inline size_t EventBus::Subscribe(Handler handler)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const size_t id = m_nextId++;
+    auto& vec = m_subs[std::type_index(typeid(T))];
+    vec.push_back({id, std::move(handler)});
+    LogSystem::Instance().Debug("Subscribed handler {} for {}", id, typeid(T).name());
+    return id;
+}
+
+template<class T>
+inline void EventBus::Publish(const T& event)
+{
+    std::vector<Subscription> subsCopy;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_subs.find(std::type_index(typeid(T)));
+        if (it != m_subs.end())
+            subsCopy = it->second;
+    }
+
+    LogSystem::Instance().Debug("Publishing {} to {} subscriber(s)", typeid(T).name(), subsCopy.size());
+
+    std::any payload = std::cref(event);
+    for (const auto& sub : subsCopy)
+    {
+        try {
+            sub.handler(payload);
+        } catch (...) {
+            LogSystem::Instance().Error("Exception in event handler {}", sub.id);
+        }
+    }
+}
+

--- a/tests/core/TestEventBus.cpp
+++ b/tests/core/TestEventBus.cpp
@@ -1,0 +1,103 @@
+#include "core/EventBus.h"
+#include "core/LogSystem.h"
+#include <gtest/gtest.h>
+#include <spdlog/sinks/base_sink.h>
+#include <atomic>
+#include <thread>
+#include <mutex>
+
+struct FooEvent { int v; };
+
+class CollectSinkEB : public spdlog::sinks::base_sink<std::mutex>
+{
+public:
+    std::vector<std::string> messages;
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        spdlog::memory_buf_t buf;
+        base_sink<std::mutex>::formatter_->format(msg, buf);
+        messages.emplace_back(buf.begin(), buf.end());
+    }
+
+    void flush_() override { messages.clear(); }
+};
+
+TEST(EventBus, SubscribeAndPublish)
+{
+    auto& bus = EventBus::Instance();
+    int value = 0;
+    size_t id = bus.Subscribe<FooEvent>([&](const std::any& e){
+        const auto& ev = std::any_cast<const std::reference_wrapper<const FooEvent>&>(e).get();
+        value = ev.v;
+    });
+    FooEvent fe{42};
+    bus.Publish(fe);
+    EXPECT_EQ(value, 42);
+    bus.Unsubscribe(id);
+}
+
+TEST(EventBus, Unsubscribe)
+{
+    auto& bus = EventBus::Instance();
+    int count = 0;
+    size_t id = bus.Subscribe<FooEvent>([&](const std::any&){ ++count; });
+    bus.Unsubscribe(id);
+    bus.Publish(FooEvent{1});
+    EXPECT_EQ(count, 0);
+}
+
+TEST(EventBus, MultipleSubscribers)
+{
+    auto& bus = EventBus::Instance();
+    std::vector<int> order;
+    size_t id1 = bus.Subscribe<FooEvent>([&](const std::any&){ order.push_back(1); });
+    size_t id2 = bus.Subscribe<FooEvent>([&](const std::any&){ order.push_back(2); });
+    bus.Publish(FooEvent{0});
+    ASSERT_EQ(order.size(), 2u);
+    EXPECT_EQ(order[0], 1);
+    EXPECT_EQ(order[1], 2);
+    bus.Unsubscribe(id1);
+    bus.Unsubscribe(id2);
+}
+
+TEST(EventBus, ThreadSafety)
+{
+    auto& bus = EventBus::Instance();
+    std::atomic<int> counter{0};
+    size_t sub = bus.Subscribe<FooEvent>([&](const std::any&){ counter.fetch_add(1); });
+
+    auto publishTask = [&](){
+        for(int i=0;i<100;i++) bus.Publish(FooEvent{i});
+    };
+    auto subscribeTask = [&](){
+        for(int i=0;i<100;i++) {
+            size_t id = bus.Subscribe<FooEvent>([](const std::any&){});
+            bus.Unsubscribe(id);
+        }
+    };
+    std::thread t1(publishTask), t2(publishTask), t3(subscribeTask), t4(subscribeTask);
+    t1.join(); t2.join(); t3.join(); t4.join();
+
+    EXPECT_EQ(counter.load(), 200);
+    bus.Unsubscribe(sub);
+}
+
+TEST(EventBus, UnknownUnsubscribe)
+{
+    auto& log = LogSystem::Instance();
+    auto sink = std::make_shared<CollectSinkEB>();
+    log.SetCustomSinkForTesting(sink);
+
+    auto& bus = EventBus::Instance();
+    bus.Unsubscribe(9999);
+
+    ASSERT_FALSE(sink->messages.empty());
+    bool foundWarn = false;
+    for(const auto& msg : sink->messages)
+        if(msg.find("[warn]") != std::string::npos || msg.find("[warning]") != std::string::npos)
+            foundWarn = true;
+    EXPECT_TRUE(foundWarn);
+}
+


### PR DESCRIPTION
## Summary
- add a global `EventBus` with thread-safe subscribe/publish
- log actions via existing `LogSystem`
- unit tests for new EventBus behaviour
- build the EventBus and tests in CMake

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build . --parallel`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6852e00fd9a08324934f03eeee652f47