### PR TITLE
Add BatchRenderer skeleton with tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 
 # Autres dépendances
 find_package(nlohmann_json CONFIG REQUIRED)
+find_package(OpenGL REQUIRED)
 
 # Tests seulement si demandés et supportés
 if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
@@ -63,6 +64,10 @@ add_library(engine
     src/core/LogSystem.h
     src/core/EventBus.cpp
     src/core/EventBus.h
+    # Renderer
+    src/renderer/BatchRenderer.cpp
+    src/renderer/BatchRenderer.h
+    src/renderer/RenderEvents.h
 )
 
 # Alias pour usage externe
@@ -76,11 +81,12 @@ target_include_directories(engine
 )
 
 # Liens des dépendances de base
-target_link_libraries(engine 
-    PUBLIC 
+target_link_libraries(engine
+    PUBLIC
         $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
         $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
         spdlog::spdlog
+        OpenGL::GL
 )
 
 # Configuration du compilateur
@@ -168,6 +174,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/EngineTests.cpp
         tests/core/TestLogSystem.cpp
         tests/core/TestEventBus.cpp
+        tests/renderer/TestBatchRenderer.cpp
     )
     
     target_link_libraries(engine_tests

--- a/src/renderer/BatchRenderer.cpp
+++ b/src/renderer/BatchRenderer.cpp
@@ -1,0 +1,216 @@
+#include "renderer/BatchRenderer.h"
+#include "renderer/RenderEvents.h"
+
+#include <glm/gtc/matrix_transform.hpp>
+
+#ifndef TESTING
+#  ifdef GRAPHICS_API_GLES
+#    include <GLES2/gl2.h>
+#  else
+#    include <GL/gl.h>
+#  endif
+#endif
+
+#ifndef GLSL_VERSION
+#ifdef GRAPHICS_API_GLES
+#define GLSL_VERSION "#version 100\n"
+#else
+#define GLSL_VERSION "#version 330 core\n"
+#endif
+#endif
+
+#ifdef PROMETHEAN_DEBUG
+#define GL_CHECK(x) do { x; GLenum e = glGetError(); \
+    if(e!=GL_NO_ERROR) LogSystem::Instance().Warn("GL error {} at " #x, (int)e); } while(0)
+#else
+#define GL_CHECK(x) x
+#endif
+
+#ifdef TESTING
+// Minimal stubs of GL when testing without a real context
+using GLenum = unsigned int;
+using GLuint = unsigned int;
+using GLint = int;
+using GLsizei = int;
+using GLfloat = float;
+using GLsizeiptr = long long;
+using GLintptr = long long;
+using GLboolean = unsigned char;
+#ifndef GL_NO_ERROR
+#define GL_NO_ERROR 0
+#endif
+#define GL_ARRAY_BUFFER 0
+#define GL_DYNAMIC_DRAW 0
+#define GL_FLOAT 0
+#define GL_FALSE 0
+#define GL_VERTEX_SHADER 0
+#define GL_FRAGMENT_SHADER 0
+#define GL_COMPILE_STATUS 0
+#define GL_LINK_STATUS 0
+#define GL_TRIANGLES 0
+using GLsizeiptr = long long;
+using GLintptr = long long;
+using GLboolean = unsigned char;
+
+static void glGenVertexArrays(GLsizei n, GLuint* arr){ for(int i=0;i<n;++i) arr[i]=1+i; }
+static void glGenBuffers(GLsizei n, GLuint* arr){ for(int i=0;i<n;++i) arr[i]=1+i; }
+static GLuint glCreateShader(GLenum){ return 1; }
+static void glShaderSource(GLuint, GLsizei, const char* const*, const GLint*){}
+static void glCompileShader(GLuint){}
+static void glGetShaderiv(GLuint, GLenum, GLint* param){ *param=1; }
+static GLuint glCreateProgram(){ return 1; }
+static void glAttachShader(GLuint, GLuint){}
+static void glLinkProgram(GLuint){}
+static void glGetProgramiv(GLuint, GLenum, GLint* param){ *param=1; }
+static void glDeleteShader(GLuint){}
+static void glDeleteProgram(GLuint){}
+static void glBindVertexArray(GLuint){}
+static void glBindBuffer(GLenum, GLuint){}
+static void glBufferData(GLenum, GLsizeiptr, const void*, GLenum){}
+static void glBufferSubData(GLenum, GLintptr, GLsizeiptr, const void*){}
+static void glEnableVertexAttribArray(GLuint){}
+static void glVertexAttribPointer(GLuint, GLint, GLenum, GLboolean, GLsizei, const void*){}
+static void glUseProgram(GLuint){}
+static GLint glGetUniformLocation(GLuint, const char*){ return 0; }
+static void glUniformMatrix4fv(GLint, GLsizei, GLboolean, const GLfloat*){}
+static void glUniform4fv(GLint, GLsizei, const GLfloat*){}
+static void glViewport(GLint, GLint, GLsizei, GLsizei){}
+static void glDrawArrays(GLenum, GLint, GLsizei){}
+static void glDeleteVertexArrays(GLsizei, const GLuint*){}
+static void glDeleteBuffers(GLsizei, const GLuint*){}
+static GLenum glGetError(){ return 0; }
+#endif
+
+namespace {
+
+const char* vertexSrc =
+    GLSL_VERSION
+    "layout(location=0) in vec2 aPos;\n"
+    "uniform mat4 u_proj;\n"
+    "void main(){\n"
+    "    gl_Position = u_proj * vec4(aPos, 0.0, 1.0);\n"
+    "}\n";
+
+const char* fragmentSrc =
+    GLSL_VERSION
+#ifdef GRAPHICS_API_GLES
+    "precision mediump float;\n"
+#endif
+    "uniform vec4 u_color;\n"
+    "void main(){\n"
+    "    gl_FragColor = u_color;\n"
+    "}\n";
+}
+
+BatchRenderer::BatchRenderer() = default;
+BatchRenderer::~BatchRenderer() { Shutdown(); }
+
+bool BatchRenderer::Init()
+{
+    if (m_initialized)
+        return true;
+
+    GL_CHECK(glGenVertexArrays(1, &m_vao));
+    GL_CHECK(glGenBuffers(1, &m_vbo));
+    GL_CHECK(glBindVertexArray(m_vao));
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, m_vbo));
+    GL_CHECK(glBufferData(GL_ARRAY_BUFFER, sizeof(float)*4*6, nullptr, GL_DYNAMIC_DRAW));
+    GL_CHECK(glEnableVertexAttribArray(0));
+    GL_CHECK(glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4*sizeof(float), (void*)0));
+
+    GLuint vert = glCreateShader(GL_VERTEX_SHADER);
+    GL_CHECK(glShaderSource(vert, 1, &vertexSrc, nullptr));
+    GL_CHECK(glCompileShader(vert));
+    GLint status;
+    GL_CHECK(glGetShaderiv(vert, GL_COMPILE_STATUS, &status));
+
+    GLuint frag = glCreateShader(GL_FRAGMENT_SHADER);
+    GL_CHECK(glShaderSource(frag, 1, &fragmentSrc, nullptr));
+    GL_CHECK(glCompileShader(frag));
+    GL_CHECK(glGetShaderiv(frag, GL_COMPILE_STATUS, &status));
+
+    m_shader = glCreateProgram();
+    GL_CHECK(glAttachShader(m_shader, vert));
+    GL_CHECK(glAttachShader(m_shader, frag));
+    GL_CHECK(glLinkProgram(m_shader));
+    GL_CHECK(glGetProgramiv(m_shader, GL_LINK_STATUS, &status));
+
+    GL_CHECK(glDeleteShader(vert));
+    GL_CHECK(glDeleteShader(frag));
+
+    m_initialized = true;
+    return true;
+}
+
+void BatchRenderer::Shutdown()
+{
+    if (!m_initialized)
+        return;
+    GL_CHECK(glDeleteBuffers(1, &m_vbo));
+    GL_CHECK(glDeleteVertexArrays(1, &m_vao));
+    GL_CHECK(glDeleteProgram(m_shader));
+    m_vao = m_vbo = m_shader = 0;
+    m_initialized = false;
+}
+
+void BatchRenderer::Begin(int screenWidth, int screenHeight)
+{
+    if (!m_initialized)
+    {
+        LogSystem::Instance().Error("BatchRenderer::Begin without Init");
+        return;
+    }
+
+    LogSystem::Instance().Debug("BatchRenderer Begin");
+    GL_CHECK(glViewport(0, 0, screenWidth, screenHeight));
+    glm::mat4 proj = glm::ortho(0.f, (float)screenWidth, (float)screenHeight, 0.f);
+    GL_CHECK(glUseProgram(m_shader));
+    GLint loc = glGetUniformLocation(m_shader, "u_proj");
+    GL_CHECK(glUniformMatrix4fv(loc, 1, GL_FALSE, &proj[0][0]));
+}
+
+void BatchRenderer::DrawQuad(const glm::vec2& pos, const glm::vec2& size,
+                             uint32_t /*textureId*/, const glm::vec4& color)
+{
+    if (!m_initialized)
+    {
+        LogSystem::Instance().Error("DrawQuad called before Init");
+        return;
+    }
+
+    LogSystem::Instance().Debug("BatchRenderer DrawQuad");
+    float x = pos.x; float y = pos.y; float w=size.x; float h=size.y;
+    const float verts[24] = {
+        x,     y,     0.f, 0.f,
+        x+w,   y,     1.f, 0.f,
+        x+w,   y+h,   1.f, 1.f,
+        x,     y,     0.f, 0.f,
+        x+w,   y+h,   1.f, 1.f,
+        x,     y+h,   0.f, 1.f
+    };
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, m_vbo));
+    GL_CHECK(glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(verts), verts));
+    GLint loc = glGetUniformLocation(m_shader, "u_color");
+    GL_CHECK(glUniform4fv(loc, 1, &color[0]));
+    GL_CHECK(glUseProgram(m_shader));
+    GL_CHECK(glBindVertexArray(m_vao));
+    GL_CHECK(glDrawArrays(GL_TRIANGLES, 0, 6));
+}
+
+void BatchRenderer::Flush()
+{
+    if (!m_initialized)
+    {
+        LogSystem::Instance().Error("Flush called before Init");
+        return;
+    }
+
+    LogSystem::Instance().Debug("BatchRenderer Flush");
+    EventBus::Instance().Publish(FrameRenderedEvent{});
+}
+
+void BatchRenderer::End()
+{
+    Flush();
+}
+

--- a/src/renderer/BatchRenderer.h
+++ b/src/renderer/BatchRenderer.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "core/EventBus.h"
+#include "core/LogSystem.h"
+#include <glm/vec2.hpp>
+#include <glm/vec4.hpp>
+#include <cstdint>
+
+/**
+ * @brief Minimal 2D sprite/quad renderer (first iteration).
+ *
+ * *Not* yet batching multiple quads; each DrawQuad issues its own draw call.
+ */
+class BatchRenderer
+{
+public:
+    BatchRenderer();
+    ~BatchRenderer();
+
+    bool Init();                 ///< Compile shaders, create VAO/VBO (returns success)
+    void Shutdown();             ///< Delete GL resources
+
+    void Begin(int screenWidth, int screenHeight);
+    void DrawQuad(const glm::vec2& pos, const glm::vec2& size,
+                  uint32_t textureId = 0,
+                  const glm::vec4& color = {1.f, 1.f, 1.f, 1.f});
+    void Flush();                ///< glDrawArrays, publish FrameRenderedEvent
+    void End();                  ///< Just calls Flush() for now
+
+private:
+    uint32_t m_vao{0}, m_vbo{0}, m_shader{0};
+    bool m_initialized{false};
+#ifdef TESTING
+public:
+    uint32_t GetVao() const { return m_vao; }
+    uint32_t GetVbo() const { return m_vbo; }
+    uint32_t GetShader() const { return m_shader; }
+#endif
+};
+

--- a/src/renderer/RenderEvents.h
+++ b/src/renderer/RenderEvents.h
@@ -1,0 +1,2 @@
+#pragma once
+struct FrameRenderedEvent {};

--- a/tests/renderer/TestBatchRenderer.cpp
+++ b/tests/renderer/TestBatchRenderer.cpp
@@ -1,0 +1,79 @@
+#include "renderer/BatchRenderer.h"
+#include "renderer/RenderEvents.h"
+#include "core/EventBus.h"
+#include "core/LogSystem.h"
+#include <gtest/gtest.h>
+#include <spdlog/sinks/base_sink.h>
+#include <mutex>
+
+class CollectSinkBR : public spdlog::sinks::base_sink<std::mutex>
+{
+public:
+    std::vector<std::string> messages;
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        spdlog::memory_buf_t buf;
+        base_sink<std::mutex>::formatter_->format(msg, buf);
+        messages.emplace_back(buf.begin(), buf.end());
+    }
+    void flush_() override { messages.clear(); }
+};
+
+TEST(BatchRenderer, InitSuccess)
+{
+    BatchRenderer br;
+    EXPECT_TRUE(br.Init());
+    br.Shutdown();
+}
+
+TEST(BatchRenderer, DoubleInit)
+{
+    BatchRenderer br;
+    ASSERT_TRUE(br.Init());
+    uint32_t vao = br.GetVao();
+    EXPECT_TRUE(br.Init());
+    EXPECT_EQ(vao, br.GetVao());
+    br.Shutdown();
+}
+
+TEST(BatchRenderer, BeginWithoutInit)
+{
+    auto sink = std::make_shared<CollectSinkBR>();
+    LogSystem::Instance().SetCustomSinkForTesting(sink);
+    BatchRenderer br;
+    br.Begin(100,100);
+    bool found = false;
+    for(const auto& msg : sink->messages)
+        if(msg.find("error") != std::string::npos)
+            found = true;
+    EXPECT_TRUE(found);
+}
+
+TEST(BatchRenderer, DrawAfterShutdown)
+{
+    auto sink = std::make_shared<CollectSinkBR>();
+    LogSystem::Instance().SetCustomSinkForTesting(sink);
+    BatchRenderer br;
+    ASSERT_TRUE(br.Init());
+    br.Shutdown();
+    br.DrawQuad({0,0}, {10,10});
+    bool found = false;
+    for(const auto& msg : sink->messages)
+        if(msg.find("error") != std::string::npos)
+            found = true;
+    EXPECT_TRUE(found);
+}
+
+TEST(BatchRenderer, PublishFrameEvent)
+{
+    BatchRenderer br;
+    ASSERT_TRUE(br.Init());
+    int count = 0;
+    auto id = EventBus::Instance().Subscribe<FrameRenderedEvent>([&](const std::any&){ ++count; });
+    br.Flush();
+    EventBus::Instance().Unsubscribe(id);
+    EXPECT_EQ(count,1);
+    br.Shutdown();
+}
+


### PR DESCRIPTION
## Summary
- implement basic BatchRenderer for 2D quads
- publish `FrameRenderedEvent` on flush
- integrate renderer sources into build and link OpenGL
- add unit tests for BatchRenderer

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build . --parallel`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68540abcaa2483248c6d986923b36b0d