### PR TITLE
Implement UI Button widget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ add_library(engine
     # ── Renderer ────────────────────────────────────────────────────
     src/renderer/BatchRenderer.cpp     src/renderer/BatchRenderer.h
     src/renderer/RenderEvents.h
+    # ── UI -------------------------------------------------------------------
+    src/ui/Button.cpp                  src/ui/Button.h
+    src/ui/Widget.h
+    # ── Assets ---------------------------------------------------------------
+    src/assets/AssetManager.h
 )
 add_library(Promethean::Engine ALIAS engine)
 
@@ -165,6 +170,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/core/TestLogSystem.cpp
         tests/core/TestEventBus.cpp
         tests/renderer/TestBatchRenderer.cpp
+        tests/ui/TestButton.cpp
     )
 
     target_link_libraries(engine_tests

--- a/src/assets/AssetManager.h
+++ b/src/assets/AssetManager.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <cstdint>
+
+using TextureHandle = uint32_t;
+
+/**
+ * @brief Minimal asset manager used for loading textures.
+ *
+ * This is a placeholder implementation meant for unit tests.
+ */
+class AssetManager {
+public:
+    static AssetManager& Instance();
+
+    /** Load a texture and return its handle. */
+    TextureHandle LoadTexture(const std::string& path);
+
+#ifdef TESTING
+    void Reset();
+#endif
+
+private:
+    AssetManager() = default;
+    std::unordered_map<std::string, TextureHandle> m_loaded;
+    TextureHandle m_nextHandle{1};
+};
+
+inline AssetManager& AssetManager::Instance()
+{
+    static AssetManager instance;
+    return instance;
+}
+
+inline TextureHandle AssetManager::LoadTexture(const std::string& path)
+{
+    auto it = m_loaded.find(path);
+    if(it != m_loaded.end())
+        return it->second;
+    TextureHandle handle = m_nextHandle++;
+    m_loaded[path] = handle;
+    return handle;
+}
+
+#ifdef TESTING
+inline void AssetManager::Reset()
+{
+    m_loaded.clear();
+    m_nextHandle = 1;
+}
+#endif
+

--- a/src/ui/Button.cpp
+++ b/src/ui/Button.cpp
@@ -1,0 +1,87 @@
+#include "ui/Button.h"
+
+#include "renderer/BatchRenderer.h"
+#include <cassert>
+
+Button::Button(const std::string& id,
+               const std::string& textureNormal,
+               const std::string& textureHover,
+               const std::string& texturePressed)
+    : m_id(id)
+{
+    m_texNormal  = AssetManager::Instance().LoadTexture(textureNormal);
+    m_texHover   = AssetManager::Instance().LoadTexture(textureHover);
+    m_texPressed = AssetManager::Instance().LoadTexture(texturePressed);
+
+    assert(m_texNormal && m_texHover && m_texPressed && "Invalid texture handle");
+    m_state = State::NORMAL;
+}
+
+void Button::Draw(BatchRenderer& renderer)
+{
+    TextureHandle tex = m_texNormal;
+    switch(m_state)
+    {
+        case State::HOVER:   tex = m_texHover;   break;
+        case State::PRESSED: tex = m_texPressed; break;
+        default: break;
+    }
+
+    renderer.BindTexture(tex);
+    renderer.DrawQuad({static_cast<float>(m_bounds.x), static_cast<float>(m_bounds.y)},
+                      {static_cast<float>(m_bounds.w), static_cast<float>(m_bounds.h)});
+}
+
+bool Button::HandleEvent(const SDL_Event& event)
+{
+    const bool inside =
+        event.type == SDL_MOUSEMOTION || event.type == SDL_MOUSEBUTTONDOWN || event.type == SDL_MOUSEBUTTONUP ?
+        (event.button.x >= m_bounds.x && event.button.x < m_bounds.x + m_bounds.w &&
+         event.button.y >= m_bounds.y && event.button.y < m_bounds.y + m_bounds.h) : false;
+
+    switch(event.type)
+    {
+        case SDL_MOUSEMOTION:
+            if(inside && m_state == State::NORMAL)
+            {
+                m_state = State::HOVER;
+                LogSystem::Instance().Debug("Button {} state -> HOVER", m_id);
+            }
+            else if(!inside && m_state != State::PRESSED)
+            {
+                if(m_state != State::NORMAL)
+                {
+                    m_state = State::NORMAL;
+                    LogSystem::Instance().Debug("Button {} state -> NORMAL", m_id);
+                }
+            }
+            break;
+        case SDL_MOUSEBUTTONDOWN:
+            if(inside && event.button.button == SDL_BUTTON_LEFT)
+            {
+                m_state = State::PRESSED;
+                LogSystem::Instance().Debug("Button {} state -> PRESSED", m_id);
+            }
+            break;
+        case SDL_MOUSEBUTTONUP:
+            if(m_state == State::PRESSED)
+            {
+                if(inside && event.button.button == SDL_BUTTON_LEFT)
+                {
+                    m_state = State::HOVER;
+                    LogSystem::Instance().Debug("Button {} clicked", m_id);
+                    EventBus::Instance().Publish(ButtonClickedEvent{m_id});
+                }
+                else
+                {
+                    m_state = State::NORMAL;
+                    LogSystem::Instance().Debug("Button {} state -> NORMAL", m_id);
+                }
+            }
+            break;
+        default:
+            break;
+    }
+    return true;
+}
+

--- a/src/ui/Button.h
+++ b/src/ui/Button.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "ui/Widget.h"
+#include "core/EventBus.h"
+#include "assets/AssetManager.h"
+#include "core/LogSystem.h"
+#include <string>
+#include <SDL.h>
+#include <glm/vec2.hpp>
+
+/// Public state enumeration used for testing
+enum class ButtonState { NORMAL, HOVER, PRESSED };
+
+/** Event published when a button is clicked. */
+struct ButtonClickedEvent {
+    std::string buttonId;
+};
+
+/**
+ * @brief Interactive button widget with three visual states.
+ */
+class Button : public Widget {
+public:
+    /**
+     * @brief Construct a button with textures for each state.
+     * @param id Identifier of the button.
+     * @param textureNormal Path to the normal state texture.
+     * @param textureHover Path to the hover state texture.
+     * @param texturePressed Path to the pressed state texture.
+     */
+    Button(const std::string& id,
+           const std::string& textureNormal,
+           const std::string& textureHover,
+           const std::string& texturePressed);
+
+    void Draw(BatchRenderer& renderer) override;
+    bool HandleEvent(const SDL_Event& event) override;
+
+#ifdef TESTING
+    ButtonState GetState() const { return static_cast<ButtonState>(m_state); }
+#endif
+
+private:
+    std::string m_id;
+    TextureHandle m_texNormal, m_texHover, m_texPressed;
+    enum class State { NORMAL, HOVER, PRESSED } m_state{State::NORMAL};
+    SDL_Rect m_bounds{0,0,100,50};
+};
+

--- a/src/ui/Widget.h
+++ b/src/ui/Widget.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "renderer/BatchRenderer.h"
+#include <SDL.h>
+
+/**
+ * @brief Base class for UI widgets.
+ */
+class Widget {
+public:
+    virtual ~Widget() = default;
+
+    /** Draw the widget using the provided renderer. */
+    virtual void Draw(BatchRenderer& renderer) = 0;
+
+    /** Handle an SDL event. */
+    virtual bool HandleEvent(const SDL_Event& event) = 0;
+};
+

--- a/tests/ui/TestButton.cpp
+++ b/tests/ui/TestButton.cpp
@@ -1,0 +1,91 @@
+#include "ui/Button.h"
+#include "assets/AssetManager.h"
+#include "core/EventBus.h"
+#include <gtest/gtest.h>
+
+static SDL_Event MouseMotion(int x,int y)
+{
+    SDL_Event e{};
+    e.type = SDL_MOUSEMOTION;
+    e.motion.x = x;
+    e.motion.y = y;
+    e.button.x = x;
+    e.button.y = y;
+    return e;
+}
+
+static SDL_Event MouseDown(int x,int y)
+{
+    SDL_Event e{};
+    e.type = SDL_MOUSEBUTTONDOWN;
+    e.button.button = SDL_BUTTON_LEFT;
+    e.button.x = x;
+    e.button.y = y;
+    return e;
+}
+
+static SDL_Event MouseUp(int x,int y)
+{
+    SDL_Event e{};
+    e.type = SDL_MOUSEBUTTONUP;
+    e.button.button = SDL_BUTTON_LEFT;
+    e.button.x = x;
+    e.button.y = y;
+    return e;
+}
+
+TEST(Button, NormalToHover)
+{
+    AssetManager::Instance().Reset();
+    Button btn("b","n","h","p");
+    btn.HandleEvent(MouseMotion(10,10));
+    EXPECT_EQ(btn.GetState(), ButtonState::HOVER);
+}
+
+TEST(Button, HoverToNormal)
+{
+    AssetManager::Instance().Reset();
+    Button btn("b","n","h","p");
+    btn.HandleEvent(MouseMotion(5,5));
+    btn.HandleEvent(MouseMotion(150,150));
+    EXPECT_EQ(btn.GetState(), ButtonState::NORMAL);
+}
+
+TEST(Button, PressedState)
+{
+    AssetManager::Instance().Reset();
+    Button btn("b","n","h","p");
+    btn.HandleEvent(MouseMotion(5,5));
+    btn.HandleEvent(MouseDown(5,5));
+    EXPECT_EQ(btn.GetState(), ButtonState::PRESSED);
+}
+
+TEST(Button, ClickFiresEvent)
+{
+    AssetManager::Instance().Reset();
+    Button btn("b","n","h","p");
+    int count=0;
+    auto id = EventBus::Instance().Subscribe<ButtonClickedEvent>([&](const std::any&){ ++count; });
+    btn.HandleEvent(MouseMotion(5,5));
+    btn.HandleEvent(MouseDown(5,5));
+    btn.HandleEvent(MouseUp(5,5));
+    EventBus::Instance().Unsubscribe(id);
+    EXPECT_EQ(count,1);
+    EXPECT_EQ(btn.GetState(), ButtonState::HOVER);
+}
+
+TEST(Button, NoEventOnDragOut)
+{
+    AssetManager::Instance().Reset();
+    Button btn("b","n","h","p");
+    int count=0;
+    auto id = EventBus::Instance().Subscribe<ButtonClickedEvent>([&](const std::any&){ ++count; });
+    btn.HandleEvent(MouseMotion(5,5));
+    btn.HandleEvent(MouseDown(5,5));
+    btn.HandleEvent(MouseMotion(200,200));
+    btn.HandleEvent(MouseUp(200,200));
+    EventBus::Instance().Unsubscribe(id);
+    EXPECT_EQ(count,0);
+    EXPECT_EQ(btn.GetState(), ButtonState::NORMAL);
+}
+


### PR DESCRIPTION
## Summary
- add minimal Widget base class
- implement `Button` widget with normal/hover/pressed states
- provide stub `AssetManager` for texture handles
- add tests for button state transitions and event firing
- extend CMake build for UI module and tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest -j $(nproc)`


------
https://chatgpt.com/codex/tasks/task_e_68551ebd63688324ab5c185c2addd12f