### PR TITLE
Implement horizontal and vertical UI layouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,9 @@ add_library(engine
     src/renderer/RenderEvents.h
     # ── UI -------------------------------------------------------------------
     src/ui/Button.cpp                  src/ui/Button.h
+    src/ui/HorizontalLayout.cpp        src/ui/HorizontalLayout.h
+    src/ui/VerticalLayout.cpp          src/ui/VerticalLayout.h
+    src/ui/WidgetContainer.h
     src/ui/Widget.h
     # ── Assets ---------------------------------------------------------------
     src/assets/AssetManager.h
@@ -171,6 +174,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/core/TestEventBus.cpp
         tests/renderer/TestBatchRenderer.cpp
         tests/ui/TestButton.cpp
+        tests/ui/TestLayout.cpp
     )
 
     target_link_libraries(engine_tests

--- a/src/ui/Button.cpp
+++ b/src/ui/Button.cpp
@@ -85,3 +85,15 @@ bool Button::HandleEvent(const SDL_Event& event)
     return true;
 }
 
+void Button::SetPosition(const glm::vec2& pos)
+{
+    m_bounds.x = static_cast<int>(pos.x);
+    m_bounds.y = static_cast<int>(pos.y);
+}
+
+void Button::SetSize(const glm::vec2& size)
+{
+    m_bounds.w = static_cast<int>(size.x);
+    m_bounds.h = static_cast<int>(size.y);
+}
+

--- a/src/ui/Button.h
+++ b/src/ui/Button.h
@@ -35,6 +35,8 @@ public:
 
     void Draw(BatchRenderer& renderer) override;
     bool HandleEvent(const SDL_Event& event) override;
+    void SetPosition(const glm::vec2& pos) override;
+    void SetSize(const glm::vec2& size) override;
 
 #ifdef TESTING
     ButtonState GetState() const { return static_cast<ButtonState>(m_state); }

--- a/src/ui/HorizontalLayout.cpp
+++ b/src/ui/HorizontalLayout.cpp
@@ -1,0 +1,40 @@
+#include "ui/HorizontalLayout.h"
+
+void HorizontalLayout::AddChild(Widget* child)
+{
+    m_children.push_back(child);
+    Recompute();
+}
+
+void HorizontalLayout::SetPosition(const glm::vec2& pos)
+{
+    m_position = pos;
+    Recompute();
+}
+
+void HorizontalLayout::SetSize(const glm::vec2& size)
+{
+    m_size = size;
+    Recompute();
+}
+
+void HorizontalLayout::Draw(BatchRenderer& renderer)
+{
+    assert(!m_children.empty() && "Layout has no children");
+    WidgetContainer::Draw(renderer);
+}
+
+void HorizontalLayout::Recompute()
+{
+    if(m_children.empty())
+        return;
+
+    float width = (m_size.x - m_spacing * (m_children.size() - 1)) / m_children.size();
+    float x = m_position.x;
+    for(auto* c : m_children)
+    {
+        c->SetPosition({x, m_position.y});
+        c->SetSize({width, m_size.y});
+        x += width + m_spacing;
+    }
+}

--- a/src/ui/HorizontalLayout.h
+++ b/src/ui/HorizontalLayout.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ui/WidgetContainer.h"
+#include <cassert>
+
+/**
+ * @brief Layout arranging children horizontally with spacing.
+ */
+class HorizontalLayout : public WidgetContainer {
+public:
+    explicit HorizontalLayout(float spacing = 5.f) : m_spacing(spacing) {}
+
+    void AddChild(Widget* child);
+    void SetPosition(const glm::vec2& pos) override;
+    void SetSize(const glm::vec2& size) override;
+    void Draw(BatchRenderer& renderer) override;
+    bool HandleEvent(const SDL_Event& event) override { return WidgetContainer::HandleEvent(event); }
+
+private:
+    void Recompute();
+    float m_spacing;
+};

--- a/src/ui/VerticalLayout.cpp
+++ b/src/ui/VerticalLayout.cpp
@@ -1,0 +1,40 @@
+#include "ui/VerticalLayout.h"
+
+void VerticalLayout::AddChild(Widget* child)
+{
+    m_children.push_back(child);
+    Recompute();
+}
+
+void VerticalLayout::SetPosition(const glm::vec2& pos)
+{
+    m_position = pos;
+    Recompute();
+}
+
+void VerticalLayout::SetSize(const glm::vec2& size)
+{
+    m_size = size;
+    Recompute();
+}
+
+void VerticalLayout::Draw(BatchRenderer& renderer)
+{
+    assert(!m_children.empty() && "Layout has no children");
+    WidgetContainer::Draw(renderer);
+}
+
+void VerticalLayout::Recompute()
+{
+    if(m_children.empty())
+        return;
+
+    float height = (m_size.y - m_spacing * (m_children.size() - 1)) / m_children.size();
+    float y = m_position.y;
+    for(auto* c : m_children)
+    {
+        c->SetPosition({m_position.x, y});
+        c->SetSize({m_size.x, height});
+        y += height + m_spacing;
+    }
+}

--- a/src/ui/VerticalLayout.h
+++ b/src/ui/VerticalLayout.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ui/WidgetContainer.h"
+#include <cassert>
+
+/**
+ * @brief Layout arranging children vertically with spacing.
+ */
+class VerticalLayout : public WidgetContainer {
+public:
+    explicit VerticalLayout(float spacing = 5.f) : m_spacing(spacing) {}
+
+    void AddChild(Widget* child);
+    void SetPosition(const glm::vec2& pos) override;
+    void SetSize(const glm::vec2& size) override;
+    void Draw(BatchRenderer& renderer) override;
+    bool HandleEvent(const SDL_Event& event) override { return WidgetContainer::HandleEvent(event); }
+
+private:
+    void Recompute();
+    float m_spacing;
+};

--- a/src/ui/Widget.h
+++ b/src/ui/Widget.h
@@ -2,6 +2,7 @@
 
 #include "renderer/BatchRenderer.h"
 #include <SDL.h>
+#include <glm/vec2.hpp>
 
 /**
  * @brief Base class for UI widgets.
@@ -15,5 +16,11 @@ public:
 
     /** Handle an SDL event. */
     virtual bool HandleEvent(const SDL_Event& event) = 0;
+
+    /** Set widget top-left position in pixels. */
+    virtual void SetPosition(const glm::vec2& pos) = 0;
+
+    /** Set widget size in pixels. */
+    virtual void SetSize(const glm::vec2& size) = 0;
 };
 

--- a/src/ui/WidgetContainer.h
+++ b/src/ui/WidgetContainer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "ui/Widget.h"
+#include <vector>
+#include <glm/vec2.hpp>
+
+/**
+ * @brief Base widget container storing children.
+ */
+class WidgetContainer : public Widget {
+public:
+    void AddChild(Widget* child) { m_children.push_back(child); }
+
+    void Draw(BatchRenderer& renderer) override {
+        for(auto* c : m_children) c->Draw(renderer);
+    }
+
+    bool HandleEvent(const SDL_Event& event) override {
+        bool handled = false;
+        for(auto* c : m_children)
+            handled = c->HandleEvent(event) || handled;
+        return handled;
+    }
+
+    void SetPosition(const glm::vec2& pos) override { m_position = pos; }
+    void SetSize(const glm::vec2& size) override { m_size = size; }
+
+protected:
+    glm::vec2 m_position{0.f,0.f};
+    glm::vec2 m_size{0.f,0.f};
+    std::vector<Widget*> m_children;
+};

--- a/tests/ui/TestLayout.cpp
+++ b/tests/ui/TestLayout.cpp
@@ -1,0 +1,80 @@
+#include "ui/HorizontalLayout.h"
+#include "ui/VerticalLayout.h"
+#include <gtest/gtest.h>
+
+class DummyWidget : public Widget {
+public:
+    glm::vec2 pos{0.f,0.f};
+    glm::vec2 size{0.f,0.f};
+    void Draw(BatchRenderer&) override {}
+    bool HandleEvent(const SDL_Event&) override { return false; }
+    void SetPosition(const glm::vec2& p) override { pos = p; }
+    void SetSize(const glm::vec2& s) override { size = s; }
+};
+
+TEST(HorizontalLayout, BasicPositions)
+{
+    HorizontalLayout layout;
+    DummyWidget w1, w2;
+    layout.AddChild(&w1);
+    layout.AddChild(&w2);
+    layout.SetPosition({0.f,0.f});
+    layout.SetSize({200.f,50.f});
+
+    float expectedWidth = (200.f - 5.f) / 2.f;
+    EXPECT_FLOAT_EQ(w1.pos.x, 0.f);
+    EXPECT_FLOAT_EQ(w2.pos.x, expectedWidth + 5.f);
+    EXPECT_FLOAT_EQ(w1.size.x, expectedWidth);
+    EXPECT_FLOAT_EQ(w2.size.x, expectedWidth);
+    EXPECT_FLOAT_EQ(w1.size.y, 50.f);
+}
+
+TEST(VerticalLayout, BasicPositions)
+{
+    VerticalLayout layout;
+    DummyWidget w1, w2;
+    layout.AddChild(&w1);
+    layout.AddChild(&w2);
+    layout.SetPosition({10.f,20.f});
+    layout.SetSize({100.f,200.f});
+
+    float expectedHeight = (200.f - 5.f) / 2.f;
+    EXPECT_FLOAT_EQ(w1.pos.x, 10.f);
+    EXPECT_FLOAT_EQ(w1.pos.y, 20.f);
+    EXPECT_FLOAT_EQ(w2.pos.x, 10.f);
+    EXPECT_FLOAT_EQ(w2.pos.y, 20.f + expectedHeight + 5.f);
+    EXPECT_FLOAT_EQ(w1.size.y, expectedHeight);
+    EXPECT_FLOAT_EQ(w2.size.y, expectedHeight);
+    EXPECT_FLOAT_EQ(w1.size.x, 100.f);
+}
+
+TEST(Layout, Resizing)
+{
+    HorizontalLayout layout;
+    DummyWidget w1, w2, w3;
+    layout.AddChild(&w1);
+    layout.AddChild(&w2);
+    layout.AddChild(&w3);
+    layout.SetPosition({0.f,0.f});
+    layout.SetSize({300.f,60.f});
+
+    layout.SetSize({150.f,30.f});
+    float width = (150.f - 5.f*2) / 3.f;
+    EXPECT_FLOAT_EQ(w3.pos.x, 2*(width + 5.f));
+    EXPECT_FLOAT_EQ(w2.size.x, width);
+}
+
+TEST(Layout, Spacing)
+{
+    HorizontalLayout layout(10.f);
+    DummyWidget w1, w2;
+    layout.AddChild(&w1);
+    layout.AddChild(&w2);
+    layout.SetPosition({0.f,0.f});
+    layout.SetSize({210.f,40.f});
+
+    float width = (210.f - 10.f)/2.f;
+    EXPECT_FLOAT_EQ(w2.pos.x, width + 10.f);
+    EXPECT_FLOAT_EQ(w1.size.x, width);
+}
+


### PR DESCRIPTION
## Summary
- extend Widget interface with SetPosition and SetSize
- implement WidgetContainer base class
- add HorizontalLayout and VerticalLayout widgets
- adapt Button to new interface
- provide unit tests for layouts

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build . --parallel`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6855233db44c8324a04e770ad8e96244