### PR TITLE
Add DebugOverlay primitives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,9 @@ add_library(engine
     # ── Renderer ────────────────────────────────────────────────────
     src/renderer/BatchRenderer.cpp     src/renderer/BatchRenderer.h
     src/renderer/RenderEvents.h
+    # ── Debug ---------------------------------------------------------------
+    src/debug/DebugOverlay.cpp         src/debug/DebugOverlay.h
+    src/debug/DebugPrimitives.h
     # ── UI -------------------------------------------------------------------
     src/ui/Button.cpp                  src/ui/Button.h
     src/ui/HorizontalLayout.cpp        src/ui/HorizontalLayout.h
@@ -173,6 +176,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/core/TestLogSystem.cpp
         tests/core/TestEventBus.cpp
         tests/renderer/TestBatchRenderer.cpp
+        tests/debug/TestDebugOverlay.cpp
         tests/ui/TestButton.cpp
         tests/ui/TestLayout.cpp
     )

--- a/src/debug/DebugOverlay.cpp
+++ b/src/debug/DebugOverlay.cpp
@@ -1,0 +1,81 @@
+#include "debug/DebugOverlay.h"
+#include "renderer/BatchRenderer.h"
+#include <algorithm>
+#include <cmath>
+#include <cassert>
+
+DebugOverlay& DebugOverlay::Get()
+{
+    static DebugOverlay instance;
+    return instance;
+}
+
+void DebugOverlay::AddLine(const glm::vec2& a, const glm::vec2& b, float duration)
+{
+    m_lines.push_back({a,b,duration});
+}
+
+void DebugOverlay::AddCircle(const glm::vec2& center, float radius, float duration)
+{
+    m_circles.push_back({center,radius,duration});
+}
+
+void DebugOverlay::AddBox(const glm::vec2& min, const glm::vec2& max, float duration)
+{
+    m_boxes.push_back({min,max,duration});
+}
+
+void DebugOverlay::Update(float dt)
+{
+    auto update = [dt](auto& vec)
+    {
+        for(auto& p : vec) p.duration -= dt;
+        vec.erase(std::remove_if(vec.begin(), vec.end(),
+            [](const auto& p){ return p.duration <= 0.f; }), vec.end());
+    };
+    update(m_lines);
+    update(m_circles);
+    update(m_boxes);
+}
+
+void DebugOverlay::Render(BatchRenderer& renderer)
+{
+#ifdef TESTING
+    assert(renderer.GetShader() != 0 && "Renderer not initialized");
+#endif
+    const glm::vec4 white(1.f,1.f,1.f,1.f);
+    for(const auto& l : m_lines)
+        renderer.DrawLine(l.start, l.end, white);
+
+    for(const auto& b : m_boxes)
+    {
+        renderer.DrawLine({b.min.x,b.min.y}, {b.max.x,b.min.y}, white);
+        renderer.DrawLine({b.max.x,b.min.y}, {b.max.x,b.max.y}, white);
+        renderer.DrawLine({b.max.x,b.max.y}, {b.min.x,b.max.y}, white);
+        renderer.DrawLine({b.min.x,b.max.y}, {b.min.x,b.min.y}, white);
+    }
+
+    const int SEG = 16;
+    const float step = 2.f * 3.14159265f / SEG;
+    for(const auto& c : m_circles)
+    {
+        for(int i=0;i<SEG;i++)
+        {
+            float a0 = step * i;
+            float a1 = step * (i+1);
+            glm::vec2 p0 = c.center + c.radius * glm::vec2(std::cos(a0), std::sin(a0));
+            glm::vec2 p1 = c.center + c.radius * glm::vec2(std::cos(a1), std::sin(a1));
+            renderer.DrawLine(p0, p1, white);
+        }
+    }
+}
+
+#ifdef TESTING
+void DebugOverlay::Reset()
+{
+    m_lines.clear();
+    m_circles.clear();
+    m_boxes.clear();
+}
+#endif
+

--- a/src/debug/DebugOverlay.h
+++ b/src/debug/DebugOverlay.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "debug/DebugPrimitives.h"
+#include <vector>
+#include <glm/vec2.hpp>
+
+class BatchRenderer;
+
+/**
+ * @brief Overlay storing debug primitives for rendering.
+ */
+class DebugOverlay {
+public:
+    /// Singleton accessor
+    static DebugOverlay& Get();
+
+    /** Add a line lasting for \p duration seconds. */
+    void AddLine(const glm::vec2& a, const glm::vec2& b, float duration);
+    /** Add a circle lasting for \p duration seconds. */
+    void AddCircle(const glm::vec2& center, float radius, float duration);
+    /** Add an axis-aligned box lasting for \p duration seconds. */
+    void AddBox(const glm::vec2& min, const glm::vec2& max, float duration);
+
+    /** Update primitives lifetimes and remove expired ones. */
+    void Update(float deltaTime);
+    /** Render all primitives using the provided renderer. */
+    void Render(BatchRenderer& renderer);
+
+#ifdef TESTING
+    size_t GetLineCount() const { return m_lines.size(); }
+    size_t GetCircleCount() const { return m_circles.size(); }
+    size_t GetBoxCount() const { return m_boxes.size(); }
+    void Reset();
+#endif
+
+private:
+    DebugOverlay() = default;
+
+    std::vector<DebugLine>   m_lines;
+    std::vector<DebugCircle> m_circles;
+    std::vector<DebugBox>    m_boxes;
+};
+

--- a/src/debug/DebugPrimitives.h
+++ b/src/debug/DebugPrimitives.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <glm/vec2.hpp>
+
+/** Primitive line with duration in seconds. */
+struct DebugLine {
+    glm::vec2 start;  ///< Line start point
+    glm::vec2 end;    ///< Line end point
+    float duration;   ///< Remaining lifetime
+};
+
+/** Primitive circle with duration in seconds. */
+struct DebugCircle {
+    glm::vec2 center; ///< Circle center
+    float radius;     ///< Circle radius
+    float duration;   ///< Remaining lifetime
+};
+
+/** Axis-aligned box with duration in seconds. */
+struct DebugBox {
+    glm::vec2 min;    ///< Minimum corner
+    glm::vec2 max;    ///< Maximum corner
+    float duration;   ///< Remaining lifetime
+};

--- a/src/renderer/BatchRenderer.cpp
+++ b/src/renderer/BatchRenderer.cpp
@@ -60,6 +60,7 @@ using GLboolean   = unsigned char;
 #define GL_COMPILE_STATUS  0
 #define GL_LINK_STATUS     0
 #define GL_TRIANGLES       0
+#define GL_LINES           0
 #define GL_TEXTURE_2D      0
 
 // ----------------------------------------------------------------------
@@ -290,6 +291,33 @@ void BatchRenderer::DrawQuad(const glm::vec2& pos, const glm::vec2& size,
     GL_CHECK(glDrawArrays(GL_TRIANGLES, 0, 6));
 }
 
+void BatchRenderer::DrawLine(const glm::vec2& a, const glm::vec2& b,
+                             const glm::vec4& color)
+{
+    if (!m_initialized)
+    {
+        LogSystem::Instance().Error("DrawLine called before Init");
+        return;
+    }
+
+    const float verts[8] = {
+        a.x, a.y, 0.f, 0.f,
+        b.x, b.y, 1.f, 1.f
+    };
+
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, m_vbo));
+    GL_CHECK(glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(verts), verts));
+
+    GLint locTint = glGetUniformLocation(m_shader, "u_tint");
+    GL_CHECK(glUniform4fv(locTint, 1, &color[0]));
+    GLint locTex = glGetUniformLocation(m_shader, "u_tex");
+    GL_CHECK(glUniform1i(locTex, 0));
+
+    GL_CHECK(glUseProgram(m_shader));
+    GL_CHECK(glBindVertexArray(m_vao));
+    GL_CHECK(glDrawArrays(GL_LINES, 0, 2));
+}
+
 void BatchRenderer::Flush()
 {
     if (!m_initialized)
@@ -314,5 +342,6 @@ uint32_t GetLastBoundTexture()    { return lastBoundTexture; }
 const float* GetLastBufferData()  { return lastBufferData; }
 glm::vec4 GetLastTint()           { return lastTint; }
 int      GetLastUniformTexture()  { return lastUniformTexture; }
+int      GetDrawArraysCount()     { return drawArraysCount; }
 }
 #endif

--- a/src/renderer/BatchRenderer.h
+++ b/src/renderer/BatchRenderer.h
@@ -50,6 +50,11 @@ public:
                   const QuadUV&    uv   = {},
                   const glm::vec4& tint = {1.f,1.f,1.f,1.f});
 
+    /** Draw a colored line from A to B. */
+    void DrawLine(const glm::vec2& a,
+                  const glm::vec2& b,
+                  const glm::vec4& color = {1.f,1.f,1.f,1.f});
+
     /** Flush immédiat puis publication de FrameRenderedEvent. */
     void Flush();
 
@@ -76,5 +81,6 @@ namespace TestGL {
     const float* GetLastBufferData();
     glm::vec4 GetLastTint();
     int      GetLastUniformTexture();
+    int      GetDrawArraysCount();
 }
 #endif

--- a/tests/debug/TestDebugOverlay.cpp
+++ b/tests/debug/TestDebugOverlay.cpp
@@ -1,0 +1,39 @@
+#include "debug/DebugOverlay.h"
+#include "renderer/BatchRenderer.h"
+#include <gtest/gtest.h>
+
+TEST(DebugOverlay, AddAndExpireLine)
+{
+    auto& ov = DebugOverlay::Get();
+    ov.Reset();
+    ov.AddLine({0.f,0.f},{1.f,1.f},0.1f);
+    EXPECT_EQ(ov.GetLineCount(),1u);
+    ov.Update(0.05f);
+    EXPECT_EQ(ov.GetLineCount(),1u);
+    ov.Update(0.06f);
+    EXPECT_EQ(ov.GetLineCount(),0u);
+}
+
+TEST(DebugOverlay, UpdateRemovesExpired)
+{
+    auto& ov = DebugOverlay::Get();
+    ov.Reset();
+    ov.AddLine({0,0},{1,1},0.1f);
+    ov.AddLine({1,1},{2,2},0.2f);
+    ov.Update(0.15f);
+    EXPECT_EQ(ov.GetLineCount(),1u);
+}
+
+TEST(DebugOverlay, RenderInvokesDraw)
+{
+    auto& ov = DebugOverlay::Get();
+    ov.Reset();
+    ov.AddLine({0,0},{1,1},0.2f);
+    BatchRenderer br;
+    ASSERT_TRUE(br.Init());
+    int before = TestGL::GetDrawArraysCount();
+    ov.Render(br);
+    int after = TestGL::GetDrawArraysCount();
+    EXPECT_EQ(after, before + 1);
+    br.Shutdown();
+}


### PR DESCRIPTION
## Summary
- introduce DebugOverlay singleton with line, circle and box drawing
- support primitives via DebugOverlay in engine library
- expose `DrawLine` and GL_LINES support in BatchRenderer
- add unit tests for DebugOverlay behaviour

## Testing
- `cmake --preset default` *(fails: Invalid preset)*
- `cmake -S . -B build` *(fails: toolchain file not found)*
- `cmake --build build` *(fails: no build directory)*

------
https://chatgpt.com/codex/tasks/task_e_685526001a0c83249416f1cb8d0dd3bf