### PR TITLE
Implement Slider widget and unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(engine
     src/ui/Button.cpp                  src/ui/Button.h
     src/ui/HorizontalLayout.cpp        src/ui/HorizontalLayout.h
     src/ui/VerticalLayout.cpp          src/ui/VerticalLayout.h
+    src/ui/Slider.cpp                  src/ui/Slider.h
     src/ui/WidgetContainer.h
     src/ui/Widget.h
     # ── Assets ---------------------------------------------------------------
@@ -207,6 +208,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/assets/TestAssetManager.cpp
         tests/ui/TestButton.cpp
         tests/ui/TestLayout.cpp
+        tests/ui/TestSlider.cpp
     )
 
     target_link_libraries(engine_tests

--- a/src/ui/Slider.cpp
+++ b/src/ui/Slider.cpp
@@ -1,0 +1,118 @@
+#include "ui/Slider.h"
+#include "renderer/BatchRenderer.h"
+#include <algorithm>
+#include <cmath>
+
+Slider::Slider(const std::string& id,
+               const std::string& trackTex,
+               const std::string& knobTex,
+               float initialValue)
+    : m_id(id)
+{
+    (void)trackTex;
+    (void)knobTex;
+    m_value = std::clamp(initialValue, 0.f, 1.f);
+}
+
+void Slider::SetPosition(const glm::vec2& pos)
+{
+    m_trackRect.x = static_cast<int>(pos.x);
+    m_trackRect.y = static_cast<int>(pos.y);
+    m_knobRect.y  = m_trackRect.y;
+    m_knobRect.x  = m_trackRect.x + static_cast<int>((m_trackRect.w - m_knobRect.w) * m_value);
+}
+
+void Slider::SetSize(const glm::vec2& size)
+{
+    m_trackRect.w = static_cast<int>(size.x);
+    m_trackRect.h = static_cast<int>(size.y);
+    m_knobRect.w  = m_trackRect.h;
+    m_knobRect.h  = m_trackRect.h;
+    m_knobRect.x  = m_trackRect.x + static_cast<int>((m_trackRect.w - m_knobRect.w) * m_value);
+    m_knobRect.y  = m_trackRect.y;
+}
+
+void Slider::Draw(BatchRenderer& renderer)
+{
+    renderer.DrawQuad({static_cast<float>(m_trackRect.x), static_cast<float>(m_trackRect.y)},
+                      {static_cast<float>(m_trackRect.w), static_cast<float>(m_trackRect.h)});
+    renderer.DrawQuad({static_cast<float>(m_knobRect.x), static_cast<float>(m_knobRect.y)},
+                      {static_cast<float>(m_knobRect.w), static_cast<float>(m_knobRect.h)});
+}
+
+static bool PointInRect(int x, int y, const SDL_Rect& r)
+{
+    return x >= r.x && x < r.x + r.w && y >= r.y && y < r.y + r.h;
+}
+
+void Slider::UpdateFromPosition(int x)
+{
+    int left  = m_trackRect.x;
+    int right = m_trackRect.x + m_trackRect.w - m_knobRect.w;
+    int clamped = std::clamp(x - m_knobRect.w / 2, left, right);
+    float value = 0.f;
+    if (right != left)
+        value = static_cast<float>(clamped - left) / static_cast<float>(right - left);
+    SetValue(value);
+}
+
+bool Slider::HandleEvent(const SDL_Event& event)
+{
+    switch(event.type)
+    {
+        case SDL_MOUSEBUTTONDOWN:
+            if(event.button.button == SDL_BUTTON_LEFT &&
+               PointInRect(event.button.x, event.button.y, m_knobRect))
+            {
+                m_dragging = true;
+                return true;
+            }
+            break;
+        case SDL_MOUSEBUTTONUP:
+            if(event.button.button == SDL_BUTTON_LEFT && m_dragging)
+            {
+                m_dragging = false;
+                return true;
+            }
+            break;
+        case SDL_MOUSEMOTION:
+            if(m_dragging)
+            {
+                UpdateFromPosition(event.motion.x);
+                return true;
+            }
+            break;
+        case SDL_KEYDOWN:
+            if(event.key.keysym.sym == SDLK_RIGHT)
+            {
+                SetValue(m_value + 0.02f);
+                return true;
+            }
+            else if(event.key.keysym.sym == SDLK_LEFT)
+            {
+                SetValue(m_value - 0.02f);
+                return true;
+            }
+            break;
+        default:
+            break;
+    }
+    return false;
+}
+
+void Slider::SetValue(float value)
+{
+    value = std::clamp(value, 0.f, 1.f);
+    if(std::fabs(value - m_value) < 0.01f)
+        return;
+    m_value = value;
+    m_knobRect.x = m_trackRect.x + static_cast<int>((m_trackRect.w - m_knobRect.w) * m_value);
+    SliderValueChangedEvent ev{m_id, m_value};
+    EventBus::Instance().Publish(ev);
+}
+
+float Slider::GetValue() const
+{
+    return m_value;
+}
+

--- a/src/ui/Slider.h
+++ b/src/ui/Slider.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "ui/Widget.h"
+#include "core/EventBus.h"
+#include <SDL.h>
+#include <string>
+#include <glm/vec2.hpp>
+
+/** Event fired when the slider value changes. */
+struct SliderValueChangedEvent {
+    std::string sliderId;
+    float       newValue;   ///< Normalized [0.0, 1.0]
+};
+
+/**
+ * @brief Horizontal slider widget with draggable knob.
+ */
+class Slider : public Widget {
+public:
+    Slider(const std::string& id,
+           const std::string& trackTex,
+           const std::string& knobTex,
+           float initialValue = 0.5f);
+
+    void Draw(BatchRenderer& renderer) override;
+    bool HandleEvent(const SDL_Event& event) override;
+    void SetPosition(const glm::vec2& pos) override;
+    void SetSize(const glm::vec2& size) override;
+
+    void SetValue(float value);      ///< Set normalized value [0,1]
+    float GetValue() const;
+
+#ifdef TESTING
+    const SDL_Rect& GetKnobRect() const { return m_knobRect; }
+#endif
+
+private:
+    std::string m_id;
+    float       m_value{0.f};
+    SDL_Rect    m_trackRect{0,0,100,10};
+    SDL_Rect    m_knobRect{0,0,10,10};
+    uint32_t    m_trackTexId{0};
+    uint32_t    m_knobTexId{0};
+    bool        m_dragging{false};
+    SDL_FingerID m_activeFinger{0};
+
+    void UpdateFromPosition(int x);
+};
+

--- a/tests/ui/TestSlider.cpp
+++ b/tests/ui/TestSlider.cpp
@@ -1,0 +1,94 @@
+#include "ui/Slider.h"
+#include "core/EventBus.h"
+#include <gtest/gtest.h>
+
+static SDL_Event MouseMotion(int x, int y)
+{
+    SDL_Event e{};
+    e.type = SDL_MOUSEMOTION;
+    e.motion.x = x;
+    e.motion.y = y;
+    e.button.x = x;
+    e.button.y = y;
+    return e;
+}
+
+static SDL_Event MouseDown(int x, int y)
+{
+    SDL_Event e{};
+    e.type = SDL_MOUSEBUTTONDOWN;
+    e.button.button = SDL_BUTTON_LEFT;
+    e.button.x = x;
+    e.button.y = y;
+    return e;
+}
+
+static SDL_Event MouseUp(int x, int y)
+{
+    SDL_Event e{};
+    e.type = SDL_MOUSEBUTTONUP;
+    e.button.button = SDL_BUTTON_LEFT;
+    e.button.x = x;
+    e.button.y = y;
+    return e;
+}
+
+static SDL_Event KeyDown(SDL_Keycode key)
+{
+    SDL_Event e{};
+    e.type = SDL_KEYDOWN;
+    e.key.keysym.sym = key;
+    return e;
+}
+
+TEST(Slider, InitialValue)
+{
+    Slider s("s","t","k",0.7f);
+    EXPECT_NEAR(s.GetValue(), 0.7f, 0.001f);
+}
+
+TEST(Slider, DragUpdatesValue)
+{
+    Slider s("s","t","k",0.f);
+    s.SetPosition({0.f,0.f});
+    s.SetSize({100.f,10.f});
+    auto knob = s.GetKnobRect();
+    s.HandleEvent(MouseDown(knob.x+5, knob.y+5));
+    s.HandleEvent(MouseMotion(100, knob.y+5));
+    s.HandleEvent(MouseUp(100, knob.y+5));
+    EXPECT_NEAR(s.GetValue(), 1.f, 0.05f);
+}
+
+TEST(Slider, EventFired)
+{
+    Slider s("s","t","k",0.f);
+    s.SetPosition({0.f,0.f});
+    s.SetSize({100.f,10.f});
+    int count = 0;
+    auto id = EventBus::Instance().Subscribe<SliderValueChangedEvent>([&](const std::any&){ ++count; });
+    s.SetValue(0.5f);
+    s.SetValue(0.505f);
+    s.SetValue(0.6f);
+    EventBus::Instance().Unsubscribe(id);
+    EXPECT_EQ(count,2);
+}
+
+TEST(Slider, KeyboardIncrement)
+{
+    Slider s("s","t","k",0.f);
+    s.SetPosition({0.f,0.f});
+    s.SetSize({100.f,10.f});
+    for(int i=0;i<10;i++)
+        s.HandleEvent(KeyDown(SDLK_RIGHT));
+    EXPECT_NEAR(s.GetValue(), 0.2f, 0.02f);
+}
+
+TEST(Slider, BoundsClamping)
+{
+    Slider s("s","t","k",0.5f);
+    s.SetValue(-1.f);
+    EXPECT_FLOAT_EQ(s.GetValue(), 0.f);
+    s.SetValue(2.f);
+    EXPECT_FLOAT_EQ(s.GetValue(), 1.f);
+}
+


### PR DESCRIPTION
## Summary
- implement horizontal Slider widget with drag, keyboard control, and value change event
- add unit tests covering initialization, dragging, events, keyboard increments, and bounds
- integrate new widget into build and test targets

## Testing
- `cmake .. -DPROMETHEAN_BUILD_TESTS=ON`
- `cmake --build . -j $(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_685956be16808324b47963cd7ae30caf