### PR TITLE
Implement abstract action mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ add_library(engine
     # ── Renderer ────────────────────────────────────────────────────
     src/renderer/BatchRenderer.cpp     src/renderer/BatchRenderer.h
     src/renderer/RenderEvents.h
+    # ── Input ---------------------------------------------------------------
+    src/input/ActionMapper.cpp         src/input/ActionMapper.h
+    src/input/InputManager.cpp         src/input/InputManager.h
+    src/input/PlayerAction.h
+    src/input/InputEvents.h
     # ── Debug ---------------------------------------------------------------
     src/debug/DebugOverlay.cpp         src/debug/DebugOverlay.h
     src/debug/DebugPrimitives.h
@@ -206,6 +211,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/renderer/TestBatchRenderer.cpp
         tests/debug/TestDebugOverlay.cpp
         tests/assets/TestAssetManager.cpp
+        tests/input/TestActionMapper.cpp
         tests/ui/TestButton.cpp
         tests/ui/TestLayout.cpp
         tests/ui/TestSlider.cpp

--- a/src/input/ActionMapper.cpp
+++ b/src/input/ActionMapper.cpp
@@ -1,0 +1,59 @@
+#include "input/ActionMapper.h"
+
+namespace Promethean {
+
+void ActionMapper::mapKey(SDL_Scancode key, PlayerAction action)
+{
+    m_keyToAction[static_cast<int>(key)] = action;
+}
+
+#if defined(__ANDROID__)
+void ActionMapper::mapTouchArea(const SDL_Rect& area, PlayerAction action)
+{
+    m_touchAreas.push_back({area, action});
+}
+#endif
+
+bool ActionMapper::isActionPressed(PlayerAction action) const
+{
+    return m_actionState[static_cast<size_t>(action)];
+}
+
+void ActionMapper::handleEvent(const SDL_Event& e)
+{
+    auto publish = [&](PlayerAction act, bool pressed){
+        size_t idx = static_cast<size_t>(act);
+        if(m_actionState[idx] != pressed) {
+            m_actionState[idx] = pressed;
+            EventBus::Instance().Publish(ActionStateChangedEvent{act, pressed});
+        }
+    };
+
+    switch(e.type) {
+    case SDL_KEYDOWN:
+    case SDL_KEYUP: {
+        auto it = m_keyToAction.find(static_cast<int>(e.key.keysym.scancode));
+        if(it != m_keyToAction.end())
+            publish(it->second, e.type == SDL_KEYDOWN);
+        break;
+    }
+#if defined(__ANDROID__)
+    case SDL_FINGERDOWN:
+    case SDL_FINGERUP: {
+        const int x = static_cast<int>(e.tfinger.x);
+        const int y = static_cast<int>(e.tfinger.y);
+        for(const auto& [rect, act] : m_touchAreas) {
+            if(x >= rect.x && x < rect.x + rect.w &&
+               y >= rect.y && y < rect.y + rect.h) {
+                publish(act, e.type == SDL_FINGERDOWN);
+            }
+        }
+        break;
+    }
+#endif
+    default:
+        break;
+    }
+}
+
+} // namespace Promethean

--- a/src/input/ActionMapper.h
+++ b/src/input/ActionMapper.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <unordered_map>
+#include <array>
+#include <vector>
+#include "SDL_scancode.h"
+#include "SDL_events.h"
+#include "PlayerAction.h"
+#include "core/EventBus.h"
+#include "InputEvents.h"
+
+namespace Promethean {
+
+/**
+ * @brief Maps device inputs to logical player actions.
+ */
+class ActionMapper {
+public:
+    /** Associate an SDL scancode with a player action. */
+    void mapKey(SDL_Scancode key, PlayerAction action);
+#if defined(__ANDROID__)
+    /** Associate a rectangular touch area with a player action. */
+    void mapTouchArea(const SDL_Rect& area, PlayerAction action);
+#endif
+    /** Returns true if the action is currently pressed. */
+    bool isActionPressed(PlayerAction action) const;
+
+    /** Update action states from an SDL event. */
+    void handleEvent(const SDL_Event& e);
+
+private:
+    std::unordered_map<int, PlayerAction> m_keyToAction;
+#if defined(__ANDROID__)
+    std::vector<std::pair<SDL_Rect, PlayerAction>> m_touchAreas;
+#endif
+    std::array<bool, PlayerActionCount> m_actionState{};
+};
+
+} // namespace Promethean

--- a/src/input/InputEvents.h
+++ b/src/input/InputEvents.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "PlayerAction.h"
+
+/** Event published when a mapped action changes state. */
+struct ActionStateChangedEvent {
+    PlayerAction action;
+    bool pressed;
+};

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -1,0 +1,76 @@
+#include "input/InputManager.h"
+
+namespace Promethean {
+
+InputManager::InputManager() : m_mapper(std::make_unique<ActionMapper>()) {}
+
+void InputManager::HandleEvent(const SDL_Event& e)
+{
+    switch(e.type)
+    {
+    case SDL_KEYDOWN:
+    case SDL_KEYUP:
+        if(e.key.keysym.scancode < SDL_NUM_SCANCODES)
+            m_keyState[e.key.keysym.scancode] = (e.type == SDL_KEYDOWN);
+        break;
+    case SDL_MOUSEBUTTONDOWN:
+    case SDL_MOUSEBUTTONUP:
+        if(e.button.button < m_mouseButtons.size())
+            m_mouseButtons[e.button.button] = (e.type == SDL_MOUSEBUTTONDOWN);
+        m_pointerDown = (e.type == SDL_MOUSEBUTTONDOWN);
+        m_pointerX = static_cast<float>(e.button.x);
+        m_pointerY = static_cast<float>(e.button.y);
+        break;
+    case SDL_MOUSEMOTION:
+        m_pointerX = static_cast<float>(e.motion.x);
+        m_pointerY = static_cast<float>(e.motion.y);
+        break;
+    case SDL_FINGERDOWN:
+    case SDL_FINGERUP:
+        m_pointerDown = (e.type == SDL_FINGERDOWN);
+        m_pointerX = e.tfinger.x;
+        m_pointerY = e.tfinger.y;
+        break;
+    default:
+        break;
+    }
+
+    if(m_mapper)
+        m_mapper->handleEvent(e);
+}
+
+void InputManager::Update() {}
+
+bool InputManager::IsKeyPressed(int keycode) const
+{
+    if(keycode < SDL_NUM_SCANCODES)
+        return m_keyState[keycode];
+    return false;
+}
+
+bool InputManager::IsMouseButtonPressed(int button) const
+{
+    if(button < static_cast<int>(m_mouseButtons.size()))
+        return m_mouseButtons[button];
+    return false;
+}
+
+void InputManager::GetPointerPosition(float& x, float& y) const
+{
+    x = m_pointerX;
+    y = m_pointerY;
+}
+
+bool InputManager::IsActionPressed(PlayerAction action) const
+{
+    return m_mapper ? m_mapper->isActionPressed(action) : false;
+}
+
+ActionMapper& InputManager::GetMapper()
+{
+    if(!m_mapper)
+        m_mapper = std::make_unique<ActionMapper>();
+    return *m_mapper;
+}
+
+} // namespace Promethean

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <array>
+#include <memory>
+#include "SDL_events.h"
+#include "ActionMapper.h"
+#include "PlayerAction.h"
+
+namespace Promethean {
+
+/**
+ * @brief Centralized input manager keeping raw device state.
+ */
+class InputManager {
+public:
+    InputManager();
+
+    /** Process an SDL event to update input state. */
+    void HandleEvent(const SDL_Event& e);
+
+    /** Update state each frame (currently no-op). */
+    void Update();
+
+    /** Check if a key is pressed. */
+    bool IsKeyPressed(int keycode) const;
+    /** Check if a mouse button is pressed. */
+    bool IsMouseButtonPressed(int button) const;
+    /** True if pointer or first finger is down. */
+    bool IsPointerDown() const { return m_pointerDown; }
+    /** Get current pointer position. */
+    void GetPointerPosition(float& x, float& y) const;
+
+    /** Query a mapped action state. */
+    bool IsActionPressed(PlayerAction action) const;
+
+    /** Access the internal mapper. */
+    ActionMapper& GetMapper();
+
+private:
+    std::array<bool, SDL_NUM_SCANCODES> m_keyState{};
+    std::array<bool, 8>                 m_mouseButtons{};
+    bool   m_pointerDown{false};
+    float  m_pointerX{0.f};
+    float  m_pointerY{0.f};
+
+    std::unique_ptr<ActionMapper> m_mapper;
+};
+
+} // namespace Promethean

--- a/src/input/PlayerAction.h
+++ b/src/input/PlayerAction.h
@@ -1,0 +1,12 @@
+#pragma once
+
+/**
+ * @brief Logical player actions decoupled from input devices.
+ */
+enum class PlayerAction {
+    MoveLeft, MoveRight, MoveUp, MoveDown,
+    Jump, Confirm, Cancel,
+    Count
+};
+
+static constexpr std::size_t PlayerActionCount = static_cast<std::size_t>(PlayerAction::Count);

--- a/tests/input/TestActionMapper.cpp
+++ b/tests/input/TestActionMapper.cpp
@@ -1,0 +1,66 @@
+#include "input/ActionMapper.h"
+#include "core/EventBus.h"
+#include <gtest/gtest.h>
+#include <malloc.h>
+
+using Promethean::ActionMapper;
+
+static SDL_Event KeyDown(SDL_Scancode sc)
+{
+    SDL_Event e{}; e.type = SDL_KEYDOWN; e.key.keysym.scancode = sc; return e;
+}
+static SDL_Event KeyUp(SDL_Scancode sc)
+{
+    SDL_Event e{}; e.type = SDL_KEYUP; e.key.keysym.scancode = sc; return e;
+}
+
+#if defined(__ANDROID__)
+static SDL_Event FingerDown(int x,int y)
+{
+    SDL_Event e{}; e.type=SDL_FINGERDOWN; e.tfinger.x=x; e.tfinger.y=y; return e;
+}
+#endif
+
+TEST(ActionMapper, MapKeyTriggersAction)
+{
+    ActionMapper m; m.mapKey(SDL_SCANCODE_SPACE, PlayerAction::Jump);
+    m.handleEvent(KeyDown(SDL_SCANCODE_SPACE));
+    EXPECT_TRUE(m.isActionPressed(PlayerAction::Jump));
+}
+
+TEST(ActionMapper, ActionRelease)
+{
+    ActionMapper m; m.mapKey(SDL_SCANCODE_SPACE, PlayerAction::Jump);
+    m.handleEvent(KeyDown(SDL_SCANCODE_SPACE));
+    m.handleEvent(KeyUp(SDL_SCANCODE_SPACE));
+    EXPECT_FALSE(m.isActionPressed(PlayerAction::Jump));
+}
+
+#if defined(__ANDROID__)
+TEST(ActionMapper, TouchArea)
+{
+    ActionMapper m; SDL_Rect r{0,0,100,100}; m.mapTouchArea(r, PlayerAction::Confirm);
+    m.handleEvent(FingerDown(50,50));
+    EXPECT_TRUE(m.isActionPressed(PlayerAction::Confirm));
+}
+#endif
+
+TEST(ActionMapper, NoAllocations)
+{
+    ActionMapper m; m.mapKey(SDL_SCANCODE_A, PlayerAction::MoveLeft);
+    m.handleEvent(KeyDown(SDL_SCANCODE_A)); // warm-up
+    auto before = mallinfo();
+    m.handleEvent(KeyDown(SDL_SCANCODE_A));
+    auto after = mallinfo();
+    EXPECT_EQ(after.uordblks, before.uordblks);
+}
+
+TEST(ActionMapper, EventBusPublication)
+{
+    ActionMapper m; m.mapKey(SDL_SCANCODE_B, PlayerAction::MoveRight);
+    int count=0; auto id = EventBus::Instance().Subscribe<ActionStateChangedEvent>([&](const std::any&){ ++count; });
+    m.handleEvent(KeyDown(SDL_SCANCODE_B));
+    m.handleEvent(KeyUp(SDL_SCANCODE_B));
+    EventBus::Instance().Unsubscribe(id);
+    EXPECT_EQ(count,2);
+}


### PR DESCRIPTION
## Summary
- add action mapping system to translate inputs to logical `PlayerAction`
- implement `InputManager` with action mapper support
- publish `ActionStateChangedEvent` on input transitions
- update build system and add unit tests for `ActionMapper`

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68595a3030fc8324b17be46164455572