### PR TITLE
[Tests] Rendre ActionMapper::NoAllocations portable

### DIFF
--- a/tests/input/TestActionMapper.cpp
+++ b/tests/input/TestActionMapper.cpp
@@ -1,7 +1,9 @@
 #include "input/ActionMapper.h"
 #include "core/EventBus.h"
 #include <gtest/gtest.h>
-#include <malloc.h>
+#if defined(__linux__)
+#  include <malloc.h>
+#endif
 
 using Promethean::ActionMapper;
 
@@ -49,10 +51,14 @@ TEST(ActionMapper, NoAllocations)
 {
     ActionMapper m; m.mapKey(SDL_SCANCODE_A, PlayerAction::MoveLeft);
     m.handleEvent(KeyDown(SDL_SCANCODE_A)); // warm-up
+#if defined(__linux__)
     auto before = mallinfo();
     m.handleEvent(KeyDown(SDL_SCANCODE_A));
-    auto after = mallinfo();
+    auto after  = mallinfo();
     EXPECT_EQ(after.uordblks, before.uordblks);
+#else
+    GTEST_SKIP() << "mallinfo n'est pas disponible sur cette plateforme.";
+#endif
 }
 
 TEST(ActionMapper, EventBusPublication)


### PR DESCRIPTION
## 📌 Résumé de la PR

- Ignore le test `ActionMapper.NoAllocations` lorsque `mallinfo` n'est pas disponible.
- Permet la compilation et l'exécution des tests sur Windows et macOS.

## ✅ Checklist

- [x] Le code compile
- [x] La CI passe
- [x] La PR résout un ticket précis
- [x] Tests ajoutés si nécessaire
- [x] Code clair et commenté

## 🎯 Lié au ticket

Closes #PE-217

------
https://chatgpt.com/codex/tasks/task_e_68596093221c8324aa72f35f438ce075