### PR TITLE
Fix SDL_mixer duplicate symbols in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,31 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
     )
     target_compile_definitions(engine_tests PRIVATE TESTING)
 
+    if(NOT MSVC)
+        set(WRAPPED_FUNCS
+            Mix_OpenAudio
+            Mix_CloseAudio
+            Mix_AllocateChannels
+            Mix_LoadWAV
+            Mix_LoadMUS
+            Mix_PlayChannel
+            Mix_PlayMusic
+            Mix_FadeInMusic
+            Mix_HaltChannel
+            Mix_HaltMusic
+            Mix_PauseMusic
+            Mix_ResumeMusic
+            Mix_Volume
+            Mix_VolumeMusic
+            Mix_FreeChunk
+            Mix_FreeMusic
+            Mix_GetError
+        )
+        foreach(f ${WRAPPED_FUNCS})
+            target_link_options(engine_tests PRIVATE "-Wl,--wrap=${f}")
+        endforeach()
+    endif()
+
     include(GoogleTest)
     gtest_discover_tests(engine_tests
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/audio/TestAudioEngine.cpp
+++ b/tests/audio/TestAudioEngine.cpp
@@ -6,6 +6,7 @@
 #ifdef TESTING
 extern "C" {
 static int dummy_channels = 8;
+#if defined(_WIN32)
 int Mix_OpenAudio(int, Uint16, int, int){ return 0; }
 void Mix_CloseAudio(){}
 int Mix_AllocateChannels(int n){ if(n!=-1) dummy_channels=n; return dummy_channels; }
@@ -24,6 +25,26 @@ int Mix_VolumeMusic(int v){ static int vol=MIX_MAX_VOLUME; if(v!=-1) vol=v; retu
 void Mix_FreeChunk(Mix_Chunk*){}
 void Mix_FreeMusic(Mix_Music*){}
 const char* Mix_GetError(){ return ""; }
+#else
+int __wrap_Mix_OpenAudio(int, Uint16, int, int){ return 0; }
+void __wrap_Mix_CloseAudio(){}
+int __wrap_Mix_AllocateChannels(int n){ if(n!=-1) dummy_channels=n; return dummy_channels; }
+static Uint8 dummy_data[4] = {0};
+Mix_Chunk* __wrap_Mix_LoadWAV(const char*){ return Mix_QuickLoad_RAW(dummy_data, sizeof(dummy_data)); }
+Mix_Music* __wrap_Mix_LoadMUS(const char*){ return reinterpret_cast<Mix_Music*>(0x1); }
+int __wrap_Mix_PlayChannel(int, Mix_Chunk*, int){ static int c=0; return c++; }
+int __wrap_Mix_PlayMusic(Mix_Music*, int){ return 0; }
+int __wrap_Mix_FadeInMusic(Mix_Music*, int, int){ return 0; }
+int __wrap_Mix_HaltChannel(int){ return 0; }
+int __wrap_Mix_HaltMusic(){ return 0; }
+void __wrap_Mix_PauseMusic(){}
+void __wrap_Mix_ResumeMusic(){}
+int __wrap_Mix_Volume(int, int v){ static int vol=MIX_MAX_VOLUME; if(v!=-1) vol=v; return vol; }
+int __wrap_Mix_VolumeMusic(int v){ static int vol=MIX_MAX_VOLUME; if(v!=-1) vol=v; return vol; }
+void __wrap_Mix_FreeChunk(Mix_Chunk*){}
+void __wrap_Mix_FreeMusic(Mix_Music*){}
+const char* __wrap_Mix_GetError(){ return ""; }
+#endif
 }
 #endif
 


### PR DESCRIPTION
## Summary
- use `__wrap_Mix_*` stubs under non‑Windows to avoid duplicate symbol errors
- wrap SDL_mixer symbols when linking engine_tests

## Testing
- `cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DPROMETHEAN_BUILD_TESTS=ON -DPROMETHEAN_BUILD_EXAMPLES=ON`
- `cmake --build build --target engine_tests`
- `ctest --output-on-failure -VV`

------
https://chatgpt.com/codex/tasks/task_e_685970adbf608324b345770f7f586a09