### PR TITLE
Limit SDL_mixer wrap to Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,25 +227,16 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
     )
     target_compile_definitions(engine_tests PRIVATE TESTING)
 
-    if(NOT MSVC)
+    # === Wrappers Mix_* pour Linux uniquement ===
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         set(WRAPPED_FUNCS
-            Mix_OpenAudio
-            Mix_CloseAudio
-            Mix_AllocateChannels
-            Mix_LoadWAV
-            Mix_LoadMUS
-            Mix_PlayChannel
-            Mix_PlayMusic
-            Mix_FadeInMusic
-            Mix_HaltChannel
-            Mix_HaltMusic
-            Mix_PauseMusic
-            Mix_ResumeMusic
-            Mix_Volume
-            Mix_VolumeMusic
-            Mix_FreeChunk
-            Mix_FreeMusic
-            Mix_GetError
+            Mix_OpenAudio Mix_CloseAudio Mix_AllocateChannels
+            Mix_LoadWAV   Mix_LoadMUS
+            Mix_PlayChannel Mix_PlayMusic Mix_FadeInMusic
+            Mix_HaltChannel Mix_HaltMusic
+            Mix_PauseMusic Mix_ResumeMusic
+            Mix_Volume Mix_VolumeMusic
+            Mix_FreeChunk Mix_FreeMusic Mix_GetError
         )
         foreach(f ${WRAPPED_FUNCS})
             target_link_options(engine_tests PRIVATE "-Wl,--wrap=${f}")

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,11 @@
+# Tests unitaires
+
+Ce dossier regroupe l'ensemble des tests Google Test permettant de vérifier le fonctionnement des modules du moteur.
+
+## Particularités SDL_mixer
+
+L'AudioEngine repose sur SDL_mixer. Afin d'éviter toute sortie audio ou écriture de fichier pendant les tests, les fonctions `Mix_*` sont redirigées via l'option de link `--wrap`. **Cette redirection n'est disponible que sous Linux** (linker GNU ou `lld`).
+
+Sur Windows, des stubs équivalents sont fournis directement dans les tests.
+
+Sur macOS et dans l'environnement Android NDK, le linker ne supporte pas `--wrap`. Les tests nécessitant cette fonctionnalité sont donc ignorés via `GTEST_SKIP()`.

--- a/tests/audio/TestAudioEngine.cpp
+++ b/tests/audio/TestAudioEngine.cpp
@@ -6,7 +6,26 @@
 #ifdef TESTING
 extern "C" {
 static int dummy_channels = 8;
-#if defined(_WIN32)
+#if defined(__linux__)
+int __wrap_Mix_OpenAudio(int, Uint16, int, int){ return 0; }
+void __wrap_Mix_CloseAudio(){}
+int __wrap_Mix_AllocateChannels(int n){ if(n!=-1) dummy_channels=n; return dummy_channels; }
+static Uint8 dummy_data[4] = {0};
+Mix_Chunk* __wrap_Mix_LoadWAV(const char*){ return Mix_QuickLoad_RAW(dummy_data, sizeof(dummy_data)); }
+Mix_Music* __wrap_Mix_LoadMUS(const char*){ return reinterpret_cast<Mix_Music*>(0x1); }
+int __wrap_Mix_PlayChannel(int, Mix_Chunk*, int){ static int c=0; return c++; }
+int __wrap_Mix_PlayMusic(Mix_Music*, int){ return 0; }
+int __wrap_Mix_FadeInMusic(Mix_Music*, int, int){ return 0; }
+int __wrap_Mix_HaltChannel(int){ return 0; }
+int __wrap_Mix_HaltMusic(){ return 0; }
+void __wrap_Mix_PauseMusic(){}
+void __wrap_Mix_ResumeMusic(){}
+int __wrap_Mix_Volume(int, int v){ static int vol=MIX_MAX_VOLUME; if(v!=-1) vol=v; return vol; }
+int __wrap_Mix_VolumeMusic(int v){ static int vol=MIX_MAX_VOLUME; if(v!=-1) vol=v; return vol; }
+void __wrap_Mix_FreeChunk(Mix_Chunk*){}
+void __wrap_Mix_FreeMusic(Mix_Music*){}
+const char* __wrap_Mix_GetError(){ return ""; }
+#elif defined(_WIN32)
 int Mix_OpenAudio(int, Uint16, int, int){ return 0; }
 void Mix_CloseAudio(){}
 int Mix_AllocateChannels(int n){ if(n!=-1) dummy_channels=n; return dummy_channels; }
@@ -26,24 +45,7 @@ void Mix_FreeChunk(Mix_Chunk*){}
 void Mix_FreeMusic(Mix_Music*){}
 const char* Mix_GetError(){ return ""; }
 #else
-int __wrap_Mix_OpenAudio(int, Uint16, int, int){ return 0; }
-void __wrap_Mix_CloseAudio(){}
-int __wrap_Mix_AllocateChannels(int n){ if(n!=-1) dummy_channels=n; return dummy_channels; }
-static Uint8 dummy_data[4] = {0};
-Mix_Chunk* __wrap_Mix_LoadWAV(const char*){ return Mix_QuickLoad_RAW(dummy_data, sizeof(dummy_data)); }
-Mix_Music* __wrap_Mix_LoadMUS(const char*){ return reinterpret_cast<Mix_Music*>(0x1); }
-int __wrap_Mix_PlayChannel(int, Mix_Chunk*, int){ static int c=0; return c++; }
-int __wrap_Mix_PlayMusic(Mix_Music*, int){ return 0; }
-int __wrap_Mix_FadeInMusic(Mix_Music*, int, int){ return 0; }
-int __wrap_Mix_HaltChannel(int){ return 0; }
-int __wrap_Mix_HaltMusic(){ return 0; }
-void __wrap_Mix_PauseMusic(){}
-void __wrap_Mix_ResumeMusic(){}
-int __wrap_Mix_Volume(int, int v){ static int vol=MIX_MAX_VOLUME; if(v!=-1) vol=v; return vol; }
-int __wrap_Mix_VolumeMusic(int v){ static int vol=MIX_MAX_VOLUME; if(v!=-1) vol=v; return vol; }
-void __wrap_Mix_FreeChunk(Mix_Chunk*){}
-void __wrap_Mix_FreeMusic(Mix_Music*){}
-const char* __wrap_Mix_GetError(){ return ""; }
+#define SKIP_NO_MIX_WRAP
 #endif
 }
 #endif
@@ -73,6 +75,9 @@ TEST(AudioEngine, MasterVolume){
 }
 
 TEST(AudioEngine, NoFileWrites){
+#ifdef SKIP_NO_MIX_WRAP
+    GTEST_SKIP() << "Wrap SDL_mixer non supporté sur cette plateforme.";
+#endif
     AudioEngine a; a.init();
     a.playSound("x.wav");
     SUCCEED();


### PR DESCRIPTION
## Summary
- limit Mix_* linker wrap to Linux
- adapt audio test stubs/wrappers with cross-platform guards
- skip NoFileWrites test when wrap is unsupported
- document platform limitation in docs/tests.md

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROMETHEAN_BUILD_TESTS=ON`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685974b9f7088324a514e673109cf002