### PR TITLE
Add stopSound by name

### DIFF
--- a/src/audio/AudioEngine.h
+++ b/src/audio/AudioEngine.h
@@ -23,6 +23,7 @@ public:
     int   playMusic(const std::string& name, bool loop = true, float fadeInMs = 0.0f);
     void  pauseMusic();
     void  resumeMusic();
+    void  stopSound(const std::string& name);
     void  stopAll();
 
     void  setMasterVolume(float volume);
@@ -33,6 +34,7 @@ private:
     using MusicPtr = std::unique_ptr<Mix_Music, decltype(&Mix_FreeMusic)>;
     std::unordered_map<std::string, ChunkPtr> m_sounds;
     std::unordered_map<std::string, MusicPtr> m_music;
+    std::unordered_map<int, std::string>       m_playingChannels;
     float m_masterVolume = 1.0f;
     bool  m_initialized  = false;
 };


### PR DESCRIPTION
## Summary
- track channels playing sounds
- add `stopSound` method in `AudioEngine`
- clear tracked channels on `stopAll` and shutdown
- test stopping sound by name and expose halted channel in stubs

## Testing
- `cmake -S . -B build -DPROMETHEAN_BUILD_TESTS=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685a7494906483248fccdcc162420d49