### PR TITLE
Fix vcpkg manifest install for Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,19 +200,13 @@ jobs:
       - name: Install vcpkg dependencies for Android
         run: |
           TRIPLET="arm64-android"
-          cd vcpkg
-          ./vcpkg install \
-            --x-manifest-root="${{ github.workspace }}" \
+          ./vcpkg/vcpkg install \
             --triplet=$TRIPLET \
             --x-install-root="${{ github.workspace }}/vcpkg_installed"
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_NDK_HOME }}
           VCPKG_CMAKE_SYSTEM_NAME: Android
-
-      - name: Install SDL_mixer for Android
-        run: |
-          cd vcpkg
-          ./vcpkg install sdl2-mixer:arm64-android
+          VCPKG_FEATURE_FLAGS: manifests
 
       - name: Configure CMake for Android
         run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
     "sdl2",
 
     { "name": "sdl2-image", "platform": "!android" },
-    { "name": "sdl2-mixer" },
+    { "name": "sdl2-mixer", "default-features": false },
     { "name": "sdl2-ttf",   "platform": "!android" },
 
     { "name": "glew",       "platform": "!android" },


### PR DESCRIPTION
## Summary
- install all vcpkg deps in manifest mode for Android
- disable default features for sdl2-mixer

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685a95c8cfb08324b928caaa498ee150