### PR TITLE
Fix AudioEngine initialization failures and Android SDL2_mixer target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,17 @@ if(ANDROID)
     target_compile_definitions(engine PRIVATE PROMETHEAN_ANDROID GRAPHICS_API_GLES)
 
     find_package(SDL2_mixer CONFIG REQUIRED)
-    target_link_libraries(engine PUBLIC SDL2_mixer::SDL2_mixer)
+
+    # Gérer explicitement les cibles SDL2_mixer statiques ou partagées
+    if(TARGET SDL2_mixer::SDL2_mixer)
+        set(PROM_SDL2_MIXER_TARGET SDL2_mixer::SDL2_mixer)
+    elseif(TARGET SDL2_mixer::SDL2_mixer-static)
+        set(PROM_SDL2_MIXER_TARGET SDL2_mixer::SDL2_mixer-static)
+    else()
+        message(FATAL_ERROR "Cible SDL2_mixer introuvable (ni SDL2_mixer::SDL2_mixer ni SDL2_mixer::SDL2_mixer-static)")
+    endif()
+
+    target_link_libraries(engine PUBLIC ${PROM_SDL2_MIXER_TARGET})
 
     target_link_libraries(engine PUBLIC
         android

--- a/src/audio/AudioEngine.cpp
+++ b/src/audio/AudioEngine.cpp
@@ -37,6 +37,7 @@ void AudioEngine::shutdown()
 
 int AudioEngine::playSound(const std::string& name, float volume)
 {
+    if (!m_initialized) return -1;
     Mix_Chunk* chunk = nullptr;
     auto it = m_sounds.find(name);
     if(it == m_sounds.end())
@@ -75,6 +76,7 @@ int AudioEngine::playSound(const std::string& name, float volume)
 
 int AudioEngine::playMusic(const std::string& name, bool loop, float fadeInMs)
 {
+    if (!m_initialized) return -1;
     Mix_Music* music = nullptr;
     auto it = m_music.find(name);
     if(it == m_music.end())
@@ -142,16 +144,10 @@ void AudioEngine::stopAll()
 
     Mix_HaltMusic();
     Mix_HaltChannel(-1);
-    m_playingChannels.clear();
 
-    auto safeErase = [](auto& map, auto freeFn){
-        for (auto it = map.begin(); it != map.end(); ) {
-            if (it->second) freeFn(it->second.release());
-            it = map.erase(it);
-        }
-    };
-    safeErase(m_music,  Mix_FreeMusic);
-    safeErase(m_sounds, Mix_FreeChunk);
+    m_playingChannels.clear();
+    m_sounds.clear();
+    m_music.clear();
 
     EventBus::Instance().Publish(AudioEvent{AudioEvent::Type::StopAll, "", 0.f});
 }

--- a/tests/audio/TestAudioEngine.cpp
+++ b/tests/audio/TestAudioEngine.cpp
@@ -63,7 +63,7 @@ TEST(AudioEngine, Init){
 }
 
 TEST(AudioEngine, PlaySound_ChannelsDifferent){
-    AudioEngine a; a.init();
+    AudioEngine a; ASSERT_TRUE(a.init());
     int c1 = a.playSound("beep.wav");
     int c2 = a.playSound("boop.wav");
     EXPECT_NE(c1, c2);
@@ -71,7 +71,7 @@ TEST(AudioEngine, PlaySound_ChannelsDifferent){
 }
 
 TEST(AudioEngine, MasterVolume){
-    AudioEngine a; a.init();
+    AudioEngine a; ASSERT_TRUE(a.init());
     a.setMasterVolume(0.5f);
     EXPECT_NEAR(Mix_Volume(-1,-1)/static_cast<float>(MIX_MAX_VOLUME),0.5f,0.01f);
     a.shutdown();
@@ -81,14 +81,14 @@ TEST(AudioEngine, NoFileWrites){
 #ifdef SKIP_NO_MIX_WRAP
     GTEST_SKIP() << "Wrap SDL_mixer non supporté sur cette plateforme.";
 #endif
-    AudioEngine a; a.init();
+    AudioEngine a; ASSERT_TRUE(a.init());
     a.playSound("x.wav");
     SUCCEED();
     a.shutdown();
 }
 
 TEST(AudioEngine, EventBusPublished){
-    AudioEngine a; a.init();
+    AudioEngine a; ASSERT_TRUE(a.init());
     int count=0;
     auto id = EventBus::Instance().Subscribe<AudioEvent>([&](const std::any&){ ++count; });
     a.playSound("foo.wav");
@@ -98,7 +98,7 @@ TEST(AudioEngine, EventBusPublished){
 }
 
 TEST(AudioEngine, StopAll){
-    AudioEngine a; a.init();
+    AudioEngine a; ASSERT_TRUE(a.init());
     a.playSound("s.wav");
     a.playMusic("m.ogg");
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -109,7 +109,7 @@ TEST(AudioEngine, StopAll){
 }
 
 TEST(AudioEngine, StopSoundByName){
-    AudioEngine a; a.init();
+    AudioEngine a; ASSERT_TRUE(a.init());
     int c1 = a.playSound("ding.wav");
     int c2 = a.playSound("dong.wav");
     last_halt_channel = -2;


### PR DESCRIPTION
## Summary
- verify AudioEngine initialization in unit tests
- guard AudioEngine playback functions when uninitialized
- simplify `stopAll` cleanup logic
- resolve Android SDL2_mixer target selection in CMake

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPROMETHEAN_BUILD_TESTS=ON`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685a9b208da08324867c6dae630b43e2