### PR TITLE
Fix SDL mixer stubs duplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,11 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
     find_package(GTest CONFIG REQUIRED)
     enable_testing()
 
+    set(USE_SDL_STUBS OFF)
+    if(DEFINED ENV{CI_HEADLESS} AND NOT MSVC)
+        set(USE_SDL_STUBS ON)
+    endif()
+
     add_executable(engine_tests
         tests/TestMain.cpp
         tests/EngineTests.cpp
@@ -235,8 +240,12 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/ui/TestLayout.cpp
         tests/ui/TestSlider.cpp
         tests/audio/TestAudioEngine.cpp
-        tests/mocks/SDL_mixer_stubs.cpp
     )
+
+    if(USE_SDL_STUBS)
+        target_sources(engine_tests PRIVATE tests/mocks/SDL_mixer_stubs.cpp)
+        target_compile_definitions(engine_tests PRIVATE USE_SDL_STUBS)
+    endif()
 
     target_link_libraries(engine_tests
         PRIVATE Promethean::Engine GTest::gtest

--- a/tests/audio/TestAudioEngine.cpp
+++ b/tests/audio/TestAudioEngine.cpp
@@ -5,7 +5,9 @@
 #include <thread>
 #include <chrono>
 
+#ifdef USE_SDL_STUBS
 extern "C" int stub_last_halt_channel;
+#endif
 
 using namespace Promethean;
 
@@ -59,6 +61,7 @@ TEST(AudioEngine, StopAll){
     SUCCEED();
 }
 
+#ifdef USE_SDL_STUBS
 TEST(AudioEngine, StopSoundByName){
     AudioEngine a; ASSERT_TRUE(a.init());
     int c1 = a.playSound("ding.wav");
@@ -71,3 +74,4 @@ TEST(AudioEngine, StopSoundByName){
     EXPECT_EQ(stub_last_halt_channel, c2);
     a.shutdown();
 }
+#endif

--- a/tests/mocks/SDL_mixer_stubs.cpp
+++ b/tests/mocks/SDL_mixer_stubs.cpp
@@ -3,11 +3,12 @@
 // Stubs for SDL_mixer functions used in tests. They avoid touching real audio
 // devices or files and provide deterministic behavior across platforms.
 
-extern "C" {
+extern "C" int stub_last_halt_channel = -2;
+
+namespace {
 
 static int dummy_channels = 8;
 static int last_channel = 0;
-int stub_last_halt_channel = -2;
 static int master_volume = MIX_MAX_VOLUME;
 static int music_volume = MIX_MAX_VOLUME;
 
@@ -54,4 +55,4 @@ void Mix_FreeMusic(Mix_Music*) {}
 
 const char* Mix_GetError() { return ""; }
 
-} // extern "C"
+} // namespace


### PR DESCRIPTION
## Summary
- give internal linkage to SDL mixer stubs
- allow building the stubs only when `CI_HEADLESS` env var is set
- disable StopSoundByName test unless stubs are enabled

## Testing
- `cmake -S . -B build -G "Unix Makefiles" -DPROMETHEAN_BUILD_TESTS=ON` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685aa430a3508324880342ec67b37ccb