### PR TITLE
PE-227 Fix AudioEngine tests

### DIFF
--- a/tests/audio/TestAudioEngine.cpp
+++ b/tests/audio/TestAudioEngine.cpp
@@ -2,6 +2,7 @@
 #include "core/EventBus.h"
 #include <gtest/gtest.h>
 #include <SDL_mixer.h>
+#include <string>
 #include <thread>
 #include <chrono>
 
@@ -11,7 +12,7 @@ extern "C" int stub_last_halt_channel;
 
 using namespace Promethean;
 
-constexpr auto kAudioPath = "assets/audio/";
+static const std::string kAudioPath = "assets/audio/";
 
 TEST(AudioEngine, Init){
     AudioEngine a; 

--- a/tests/mocks/SDL_mixer_stubs.cpp
+++ b/tests/mocks/SDL_mixer_stubs.cpp
@@ -12,47 +12,47 @@ static int last_channel = 0;
 static int master_volume = MIX_MAX_VOLUME;
 static int music_volume = MIX_MAX_VOLUME;
 
-int Mix_OpenAudio(int, Uint16, int, int) { return 0; }
-void Mix_CloseAudio() {}
+extern "C" int Mix_OpenAudio(int, Uint16, int, int) { return 0; }
+extern "C" void Mix_CloseAudio() {}
 
-int Mix_AllocateChannels(int n) {
+extern "C" int Mix_AllocateChannels(int n) {
     if (n != -1) dummy_channels = n;
     return dummy_channels;
 }
 
-Mix_Chunk* Mix_LoadWAV(const char*) {
+extern "C" Mix_Chunk* Mix_LoadWAV(const char*) {
     static int fake_chunk;
     return reinterpret_cast<Mix_Chunk*>(&fake_chunk);
 }
 
-Mix_Music* Mix_LoadMUS(const char*) {
+extern "C" Mix_Music* Mix_LoadMUS(const char*) {
     static int fake_music;
     return reinterpret_cast<Mix_Music*>(&fake_music);
 }
 
-int Mix_PlayChannel(int, Mix_Chunk*, int) { return last_channel++; }
-int Mix_PlayMusic(Mix_Music*, int) { return 0; }
-int Mix_FadeInMusic(Mix_Music*, int, int) { return 0; }
+extern "C" int Mix_PlayChannel(int, Mix_Chunk*, int) { return last_channel++; }
+extern "C" int Mix_PlayMusic(Mix_Music*, int) { return 0; }
+extern "C" int Mix_FadeInMusic(Mix_Music*, int, int) { return 0; }
 
-int Mix_HaltChannel(int c) { stub_last_halt_channel = c; return 0; }
-int Mix_HaltMusic() { return 0; }
+extern "C" int Mix_HaltChannel(int c) { stub_last_halt_channel = c; return 0; }
+extern "C" int Mix_HaltMusic() { return 0; }
 
-void Mix_PauseMusic() {}
-void Mix_ResumeMusic() {}
+extern "C" void Mix_PauseMusic() {}
+extern "C" void Mix_ResumeMusic() {}
 
-int Mix_Volume(int, int v) {
+extern "C" int Mix_Volume(int, int v) {
     if (v != -1) master_volume = v;
     return master_volume;
 }
 
-int Mix_VolumeMusic(int v) {
+extern "C" int Mix_VolumeMusic(int v) {
     if (v != -1) music_volume = v;
     return music_volume;
 }
 
-void Mix_FreeChunk(Mix_Chunk*) {}
-void Mix_FreeMusic(Mix_Music*) {}
+extern "C" void Mix_FreeChunk(Mix_Chunk*) {}
+extern "C" void Mix_FreeMusic(Mix_Music*) {}
 
-const char* Mix_GetError() { return ""; }
+extern "C" const char* Mix_GetError() { return ""; }
 
 } // namespace


### PR DESCRIPTION
## Summary
- fix path concatenation in audio tests using `std::string`
- expose SDL_mixer stubs with C linkage so tests run headless

## Testing
- `cmake -S . -B build -GNinja`
- `cmake --build build`
- `ctest -R AudioEngine --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_685ab6aa937c8324bff7f5a0d33cc5c8