### PR TITLE
Implement global fade out and music cross-fade

### DIFF
--- a/src/audio/AudioEngine.h
+++ b/src/audio/AudioEngine.h
@@ -14,6 +14,14 @@ struct AudioEvent {
     float       volume;
 };
 
+/** Event published when a fade starts. */
+struct AudioFadeStartedEvent {
+    int durationMs;
+};
+
+/** Event published when a fade operation completes. */
+struct AudioFadeCompletedEvent {};
+
 class AudioEngine {
 public:
     bool  init();
@@ -21,9 +29,11 @@ public:
 
     int   playSound(const std::string& name, float volume = 1.0f);
     int   playMusic(const std::string& name, bool loop = true, float fadeInMs = 0.0f);
+    bool  playMusicCrossFade(const std::string& path, int ms = 1000, bool loop = true);
     void  pauseMusic();
     void  resumeMusic();
     void  stopSound(const std::string& name);
+    bool  fadeOutAll(int ms = 500);
     void  stopAll();
 
     void  setMasterVolume(float volume);
@@ -37,6 +47,13 @@ private:
     std::unordered_map<int, std::string>       m_playingChannels;
     float m_masterVolume = 1.0f;
     bool  m_initialized  = false;
+
+    std::string m_pendingMusic;
+    bool        m_pendingLoop{true};
+    int         m_pendingFadeMs{0};
+
+    static AudioEngine* s_instance;
+    static void MusicFinishedHook();
 };
 
 }

--- a/tests/mocks/SDL_mixer_stubs.cpp
+++ b/tests/mocks/SDL_mixer_stubs.cpp
@@ -4,6 +4,8 @@
 // devices or files and provide deterministic behavior across platforms.
 
 extern "C" int stub_last_halt_channel = -2;
+extern "C" int stub_fadeout_music_calls = 0;
+extern "C" int stub_fadein_music_ms = 0;
 
 namespace {
 
@@ -37,7 +39,12 @@ extern "C" Mix_Music* Mix_LoadMUS(const char*) {
 
 extern "C" int Mix_PlayChannel(int, Mix_Chunk*, int) { return last_channel++; }
 extern "C" int Mix_PlayMusic(Mix_Music*, int) { return 0; }
-extern "C" int Mix_FadeInMusic(Mix_Music*, int, int) { return 0; }
+extern "C" int Mix_FadeInMusic(Mix_Music*, int, int ms) { stub_fadein_music_ms = ms; return 0; }
+static void (*hook_finished)(void) = nullptr;
+extern "C" void Mix_HookMusicFinished(void (*cb)(void)) { hook_finished = cb; }
+extern "C" int Mix_FadeOutMusic(int) { ++stub_fadeout_music_calls; if(hook_finished) hook_finished(); return 1; }
+extern "C" int Mix_FadeOutChannel(int, int) { return 0; }
+extern "C" int Mix_FadingMusic() { return MIX_NO_FADING; }
 
 extern "C" int Mix_HaltChannel(int c) {
     stub_last_halt_channel = c;


### PR DESCRIPTION
## Summary
- support audio fade events and cross-fade playback
- emit `AudioFadeStartedEvent` and `AudioFadeCompletedEvent`
- extend SDL_mixer stubs for fade operations
- add unit tests for fade logic

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build`
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./build/bin/engine_tests`
- `export CI_HEADLESS=1 && cmake -B build_stub -S . -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build_stub`
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./build_stub/bin/engine_tests`

------
https://chatgpt.com/codex/tasks/task_e_685ac94ecab483248b964ad9543ba925