### PR TITLE
Implement audio buses with settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(engine
     src/debug/DebugPrimitives.h
     # ── Audio ---------------------------------------------------------------
     src/audio/AudioEngine.cpp          src/audio/AudioEngine.h
+    src/audio/AudioSettings.cpp        src/audio/AudioSettings.h
     src/audio/Sound.cpp                src/audio/Sound.h
     src/audio/Music.cpp                src/audio/Music.h
     # ── UI -------------------------------------------------------------------
@@ -240,6 +241,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/ui/TestLayout.cpp
         tests/ui/TestSlider.cpp
         tests/audio/TestAudioEngine.cpp
+        tests/audio/TestAudioBus.cpp
     )
 
     file(GLOB TEST_AUDIO_FILES

--- a/src/audio/AudioEngine.h
+++ b/src/audio/AudioEngine.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include "core/EventBus.h"
 #include "SDL_mixer.h"
+#include <array>
+#include <vector>
 
 namespace Promethean {
 
@@ -22,22 +24,35 @@ struct AudioFadeStartedEvent {
 /** Event published when a fade operation completes. */
 struct AudioFadeCompletedEvent {};
 
+enum class AudioBus { BGM, SFX, UI };
+
+struct BusState {
+    int volume{MIX_MAX_VOLUME};
+    bool muted{false};
+    std::vector<int> channels;
+};
+
 class AudioEngine {
 public:
     bool  init();
     void  shutdown();
 
-    int   playSound(const std::string& name, float volume = 1.0f);
-    int   playMusic(const std::string& name, bool loop = true, float fadeInMs = 0.0f);
+    int   playSound(const std::string& name, float volume = 1.0f, AudioBus bus = AudioBus::SFX);
+    int   playMusic(const std::string& name, bool loop = true, float fadeInMs = 0.0f, AudioBus bus = AudioBus::BGM);
     bool  playMusicCrossFade(const std::string& path, int ms = 1000, bool loop = true);
     void  pauseMusic();
     void  resumeMusic();
     void  stopSound(const std::string& name);
     bool  fadeOutAll(int ms = 500);
+    bool  fadeOutBus(AudioBus bus, int ms);
     void  stopAll();
 
     void  setMasterVolume(float volume);
     float getMasterVolume() const;
+    void  setBusVolume(AudioBus bus, int vol);
+    int   getBusVolume(AudioBus bus) const;
+    void  muteBus(AudioBus bus, bool state);
+    bool  isBusMuted(AudioBus bus) const;
 
 private:
     using ChunkPtr = std::unique_ptr<Mix_Chunk, decltype(&Mix_FreeChunk)>;
@@ -51,6 +66,10 @@ private:
     std::string m_pendingMusic;
     bool        m_pendingLoop{true};
     int         m_pendingFadeMs{0};
+
+    std::array<BusState,3> m_buses{};
+
+    static void ChannelFinishedHook(int channel);
 
     static AudioEngine* s_instance;
     static void MusicFinishedHook();

--- a/src/audio/AudioSettings.cpp
+++ b/src/audio/AudioSettings.cpp
@@ -1,0 +1,28 @@
+#include "audio/AudioSettings.h"
+#include <fstream>
+
+namespace Promethean {
+
+bool AudioSettings::saveSettings(const std::string& path) const {
+    try {
+        std::ofstream ofs(path);
+        if(!ofs.good()) return false;
+        nlohmann::json j = *this;
+        ofs << j.dump(4);
+        return true;
+    } catch(...) {
+        return false;
+    }
+}
+
+AudioSettings AudioSettings::loadSettings(const std::string& path) {
+    AudioSettings s;
+    std::ifstream ifs(path);
+    if(ifs.good()) {
+        nlohmann::json j; ifs >> j;
+        s = j.get<AudioSettings>();
+    }
+    return s;
+}
+
+} // namespace Promethean

--- a/src/audio/AudioSettings.h
+++ b/src/audio/AudioSettings.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <nlohmann/json.hpp>
+#include <SDL_mixer.h>
+#include <string>
+
+namespace Promethean {
+
+struct AudioSettings {
+    int bgm = MIX_MAX_VOLUME;
+    int sfx = MIX_MAX_VOLUME;
+    int ui  = MIX_MAX_VOLUME;
+    bool muteBgm = false;
+    bool muteSfx = false;
+    bool muteUi  = false;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(AudioSettings, bgm, sfx, ui, muteBgm, muteSfx, muteUi)
+
+    bool saveSettings(const std::string& path) const;
+    static AudioSettings loadSettings(const std::string& path);
+};
+
+} // namespace Promethean

--- a/tests/audio/TestAudioBus.cpp
+++ b/tests/audio/TestAudioBus.cpp
@@ -1,0 +1,81 @@
+#include "audio/AudioEngine.h"
+#include <gtest/gtest.h>
+#ifdef USE_SDL_STUBS
+extern "C" int stub_music_volume;
+extern "C" int stub_master_volume;
+extern "C" int stub_last_volume_channel;
+extern std::vector<int> stub_fadeout_channels;
+#endif
+
+using namespace Promethean;
+
+static const std::string kAudioPath = "assets/audio/";
+
+TEST(AudioBus, DefaultState) {
+    AudioEngine a; ASSERT_TRUE(a.init());
+    EXPECT_EQ(a.getBusVolume(AudioBus::SFX), MIX_MAX_VOLUME);
+    EXPECT_FALSE(a.isBusMuted(AudioBus::BGM));
+    a.shutdown();
+}
+
+TEST(AudioBus, SetGetVolume) {
+    AudioEngine a; ASSERT_TRUE(a.init());
+    a.setBusVolume(AudioBus::SFX, 64);
+    EXPECT_EQ(a.getBusVolume(AudioBus::SFX), 64);
+    a.shutdown();
+}
+
+TEST(AudioBus, MuteState) {
+    AudioEngine a; ASSERT_TRUE(a.init());
+    a.muteBus(AudioBus::UI, true);
+    EXPECT_TRUE(a.isBusMuted(AudioBus::UI));
+    a.shutdown();
+}
+
+TEST(AudioBus, FadeOutEmptyBus) {
+    AudioEngine a; ASSERT_TRUE(a.init());
+    EXPECT_TRUE(a.fadeOutBus(AudioBus::SFX, 50));
+    a.shutdown();
+}
+
+#ifdef USE_SDL_STUBS
+TEST(AudioBus, MuteMusicUsesSDL) {
+    AudioEngine a; ASSERT_TRUE(a.init());
+    a.muteBus(AudioBus::BGM, true);
+    EXPECT_EQ(stub_music_volume, 0);
+    a.shutdown();
+}
+
+TEST(AudioBus, PlaySoundUsesBusVolume) {
+    AudioEngine a; ASSERT_TRUE(a.init());
+    a.setBusVolume(AudioBus::SFX, 32);
+    stub_last_volume_channel = -2;
+    a.playSound(kAudioPath + "beep.wav", 1.0f, AudioBus::SFX);
+    EXPECT_NE(stub_last_volume_channel, -2);
+    EXPECT_EQ(stub_master_volume, 32);
+    a.shutdown();
+}
+
+TEST(AudioBus, FadeOutMusicBus) {
+    AudioEngine a; ASSERT_TRUE(a.init());
+    a.playMusic(kAudioPath + "beep.wav");
+    extern int stub_fadeout_music_calls;
+    stub_fadeout_music_calls = 0;
+    EXPECT_TRUE(a.fadeOutBus(AudioBus::BGM, 200));
+    EXPECT_EQ(stub_fadeout_music_calls,1);
+    a.shutdown();
+}
+
+TEST(AudioBus, FadeOutSfxChannels) {
+    AudioEngine a; ASSERT_TRUE(a.init());
+    int c1 = a.playSound(kAudioPath + "beep.wav");
+    int c2 = a.playSound(kAudioPath + "boop.wav");
+    stub_fadeout_channels.clear();
+    EXPECT_TRUE(a.fadeOutBus(AudioBus::SFX, 100));
+    ASSERT_EQ(stub_fadeout_channels.size(), 2u);
+    EXPECT_EQ(stub_fadeout_channels[0], c1);
+    EXPECT_EQ(stub_fadeout_channels[1], c2);
+    a.shutdown();
+}
+#endif
+


### PR DESCRIPTION
## Summary
- introduce audio bus system to group BGM, SFX and UI sounds
- add JSON-serialisable `AudioSettings` structure
- expose bus volume, mute and fade operations in `AudioEngine`
- extend SDL mixer stubs and new unit tests for audio buses

## Testing
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685bbdfec9288324857610eff2628128