### PR TITLE
Fix headless initialization

### DIFF
--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -42,6 +42,19 @@ bool Engine::Initialize() {
     if (m_initialized)
         return true;
 
+    // When running unit tests or in CI, the engine can be initialized without
+    // any graphical output. In that case we avoid creating a window or an OpenGL
+    // context entirely.
+#ifdef HEADLESS_GL
+    if (SDL_Init(SDL_INIT_TIMER | SDL_INIT_AUDIO) != 0) {
+        spdlog::error("SDL_Init failed: {}", SDL_GetError());
+        return false;
+    }
+    m_headless = true;
+    m_initialized = true;
+    spdlog::info("Engine initialized in headless mode");
+    return true;
+#else
     // Configure SDL for headless environments (Linux CI/CD)
 #if defined(__linux__) && !defined(PROMETHEAN_ANDROID)
     if (!std::getenv("DISPLAY")) {
@@ -102,6 +115,7 @@ bool Engine::Initialize() {
 
     m_initialized = true;
     return true;
+#endif // HEADLESS_GL
 #endif // PROMETHEAN_ANDROID_CI
 }
 

--- a/src/core/Engine.h
+++ b/src/core/Engine.h
@@ -48,6 +48,7 @@ private:
     };
 
     bool m_initialized{false};
+    bool m_headless{false};
     std::unique_ptr<SDL_Window, SDLWindowDeleter> m_window;
     SDL_GLContext m_glContext{nullptr};
     BatchRenderer m_renderer;


### PR DESCRIPTION
## Summary
- allow Engine to initialize without SDL video when `HEADLESS_GL` is defined
- track headless mode in the Engine

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROMETHEAN_BUILD_TESTS=ON`
- `cmake --build build -j $(nproc)`
- `cd build && ctest --output-on-failure -R EngineTest`

------
https://chatgpt.com/codex/tasks/task_e_685be3728aec832499c73cf54105b312