### PR TITLE
Add TMX collision layer parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ add_library(engine
     # ── Assets ---------------------------------------------------------------
     src/assets/AssetManager.cpp        src/assets/AssetManager.h
     src/assets/TileMap.cpp             src/assets/TileMap.h
+    # ── Physics --------------------------------------------------------------
+    src/physics/CollisionLayer.cpp     src/physics/CollisionLayer.h
     # ── Settings -------------------------------------------------------------
     src/core/SettingsManager.cpp       src/core/SettingsManager.h
 )
@@ -269,6 +271,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/debug/TestDebugOverlay.cpp
         tests/assets/TestAssetManager.cpp
         tests/assets/TestTileMap.cpp
+        tests/physics/TestCollisionLayer.cpp
         tests/input/TestActionMapper.cpp
         tests/ui/TestButton.cpp
         tests/ui/TestLayout.cpp

--- a/src/assets/TileMap.cpp
+++ b/src/assets/TileMap.cpp
@@ -112,6 +112,23 @@ std::shared_ptr<TileMap> LoadTileMap(const std::string& path)
         map->layers.push_back(std::move(layer));
     }
 
+    for(auto ogEl = mapEl->FirstChildElement("objectgroup"); ogEl; ogEl = ogEl->NextSiblingElement("objectgroup"))
+    {
+        TileMap::ObjectGroup group{};
+        if(const char* name = ogEl->Attribute("name")) group.name = name;
+        for(auto objEl = ogEl->FirstChildElement("object"); objEl; objEl = objEl->NextSiblingElement("object"))
+        {
+            TileMap::MapObject obj{};
+            if(const char* oname = objEl->Attribute("name")) obj.name = oname;
+            objEl->QueryIntAttribute("x", &obj.pos.x);
+            objEl->QueryIntAttribute("y", &obj.pos.y);
+            objEl->QueryIntAttribute("width", &obj.size.x);
+            objEl->QueryIntAttribute("height", &obj.size.y);
+            group.objects.push_back(obj);
+        }
+        map->objectGroups.push_back(std::move(group));
+    }
+
     return map;
 }
 

--- a/src/assets/TileMap.h
+++ b/src/assets/TileMap.h
@@ -28,8 +28,18 @@ struct TileMap {
     glm::ivec2 mapSize{};
     int tileW{};
     int tileH{};
-    std::vector<TilesetInfo> tilesets;
-    std::vector<TileMapLayer> layers;
+    std::vector<TilesetInfo>   tilesets;
+    std::vector<TileMapLayer>  layers;
+    struct MapObject {
+        std::string name;
+        glm::ivec2  pos{};
+        glm::ivec2  size{};
+    };
+    struct ObjectGroup {
+        std::string name;
+        std::vector<MapObject> objects;
+    };
+    std::vector<ObjectGroup> objectGroups;
 };
 
 std::shared_ptr<TileMap> LoadTileMap(const std::string& path);

--- a/src/physics/CollisionLayer.cpp
+++ b/src/physics/CollisionLayer.cpp
@@ -1,0 +1,66 @@
+#include "physics/CollisionLayer.h"
+#include "core/LogSystem.h"
+#include <cmath>
+
+namespace Promethean {
+
+static long long Key(int x, int y) {
+    return (static_cast<long long>(x) << 32) | static_cast<unsigned int>(y);
+}
+
+std::optional<CollisionError> CollisionLayer::Build(const TileMap& map)
+{
+    m_colliders.clear();
+    m_hash.clear();
+    const TileMap::ObjectGroup* group = nullptr;
+    for(const auto& g : map.objectGroups)
+        if(g.name == "collision") { group = &g; break; }
+    if(!group)
+    {
+        LogSystem::Instance().Debug("Collision layer not found");
+        return CollisionError::MissingCollisionLayer;
+    }
+
+    for(const auto& obj : group->objects)
+    {
+        AABBCollider c;
+        c.min = glm::vec2(obj.pos);
+        c.max = glm::vec2(obj.pos + obj.size);
+        size_t index = m_colliders.size();
+        m_colliders.push_back(c);
+
+        int x0 = static_cast<int>(std::floor(c.min.x / CELL_SIZE));
+        int y0 = static_cast<int>(std::floor(c.min.y / CELL_SIZE));
+        int x1 = static_cast<int>(std::floor((c.max.x-1) / CELL_SIZE));
+        int y1 = static_cast<int>(std::floor((c.max.y-1) / CELL_SIZE));
+        for(int y=y0; y<=y1; ++y)
+            for(int x=x0; x<=x1; ++x)
+                m_hash[Key(x,y)].push_back(index);
+    }
+    return std::nullopt;
+}
+
+std::vector<AABBCollider> CollisionLayer::Query(const glm::vec2& p) const
+{
+    std::vector<AABBCollider> result;
+    result.reserve(16);
+    int cx = static_cast<int>(std::floor(p.x / CELL_SIZE));
+    int cy = static_cast<int>(std::floor(p.y / CELL_SIZE));
+    auto it = m_hash.find(Key(cx,cy));
+    if(it != m_hash.end())
+    {
+        for(size_t idx : it->second)
+        {
+            const auto& c = m_colliders[idx];
+            if(p.x >= c.min.x && p.x <= c.max.x &&
+               p.y >= c.min.y && p.y <= c.max.y)
+            {
+                result.push_back(c);
+                if(result.size() >= 16) break;
+            }
+        }
+    }
+    return result;
+}
+
+} // namespace Promethean

--- a/src/physics/CollisionLayer.h
+++ b/src/physics/CollisionLayer.h
@@ -1,0 +1,34 @@
+#pragma once
+#include "assets/TileMap.h"
+#include <glm/vec2.hpp>
+#include <unordered_map>
+#include <vector>
+#include <optional>
+
+namespace Promethean {
+
+struct AABBCollider {
+    glm::vec2 min{0.f};
+    glm::vec2 max{0.f};
+};
+
+enum class CollisionError {
+    MissingCollisionLayer
+};
+
+struct CollisionEvent {
+    AABBCollider collider;
+};
+
+class CollisionLayer {
+public:
+    std::optional<CollisionError> Build(const TileMap& map);
+    std::vector<AABBCollider> Query(const glm::vec2& p) const;
+
+private:
+    static constexpr float CELL_SIZE = 256.f;
+    std::vector<AABBCollider> m_colliders;
+    std::unordered_map<long long, std::vector<size_t>> m_hash;
+};
+
+} // namespace Promethean

--- a/tests/physics/TestCollisionLayer.cpp
+++ b/tests/physics/TestCollisionLayer.cpp
@@ -1,0 +1,53 @@
+#include "physics/CollisionLayer.h"
+#include "assets/TileMap.h"
+#include <gtest/gtest.h>
+#include <fstream>
+#include <filesystem>
+
+using namespace Promethean;
+
+static std::shared_ptr<TileMap> SimpleMap()
+{
+    const char* xml = R"(<map width='1' height='1' tilewidth='32' tileheight='32'>
+      <tileset firstgid='1' name='dummy' tilewidth='32' tileheight='32' tilecount='1' columns='1'>
+        <image source='dummy.png' width='32' height='32'/>
+      </tileset>
+      <layer name='Layer' width='1' height='1'><data encoding='csv'>0</data></layer>
+      <objectgroup name='collision'>
+        <object id='1' x='0' y='0' width='32' height='32'/>
+      </objectgroup>
+    </map>)";
+    auto tmp = std::filesystem::temp_directory_path()/"c.tmx";
+    std::ofstream(tmp) << xml;
+    return LoadTileMap(tmp.string());
+}
+
+TEST(CollisionLayer, Build_SimpleMap_ReturnsCorrectCount)
+{
+    auto map = SimpleMap();
+    ASSERT_TRUE(map);
+    CollisionLayer cl;
+    auto err = cl.Build(*map);
+    EXPECT_FALSE(err.has_value());
+    auto res = cl.Query({0.f,0.f});
+    EXPECT_EQ(res.size(),1u);
+}
+
+TEST(CollisionLayer, Query_PointOutside_ReturnsEmpty)
+{
+    auto map = SimpleMap();
+    ASSERT_TRUE(map);
+    CollisionLayer cl; cl.Build(*map);
+    auto res = cl.Query({40.f,40.f});
+    EXPECT_TRUE(res.empty());
+}
+
+TEST(CollisionLayer, Query_PointInside_ReturnsCollider)
+{
+    auto map = SimpleMap();
+    ASSERT_TRUE(map);
+    CollisionLayer cl; cl.Build(*map);
+    auto res = cl.Query({16.f,16.f});
+    ASSERT_EQ(res.size(),1u);
+    EXPECT_FLOAT_EQ(res[0].max.x,32.f);
+}


### PR DESCRIPTION
## Summary
- add object group structures to `TileMap`
- parse `<objectgroup>` elements when loading maps
- implement new `CollisionLayer` using spatial hash
- provide basic unit tests for collider queries

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j4`
- `CI_HEADLESS=1 ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685bfafa61ac8324a66d5ce76cc770ff