### PR TITLE
Add builtin baseline for vcpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ cmake --build . --parallel
 ctest --output-on-failure
 ```
 
+## 📦 Building with vcpkg
+
+This project uses **vcpkg** to manage its third-party libraries. The manifest
+specifies a fixed baseline commit so that dependency versions remain
+deterministic. Ensure your clone of vcpkg is able to access this baseline:
+
+```json
+"builtin-baseline": "f5ca1a1e2b8f6bc59f2a5b4c4b8ab0d3e7f2d5a0"
+```
+
+After bootstrapping vcpkg, install the dependencies from the manifest:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh
+./vcpkg/vcpkg install --x-manifest-root=.
+```
+
 ---
 
 ## 🧪 Tests & CI

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,21 +2,35 @@
   "name": "promethean-engine",
   "version-string": "0.1.0",
   "description": "Minimal 2D engine using SDL2",
+  "builtin-baseline": "f5ca1a1e2b8f6bc59f2a5b4c4b8ab0d3e7f2d5a0",
   "dependencies": [
     "sdl2",
-
-    { "name": "sdl2-image", "platform": "!android" },
-    { "name": "sdl2-mixer", "default-features": false },
-    { "name": "sdl2-ttf",   "platform": "!android" },
-
-    { "name": "glew",       "platform": "!android" },
-
+    {
+      "name": "sdl2-image",
+      "platform": "!android"
+    },
+    {
+      "name": "sdl2-mixer",
+      "default-features": false
+    },
+    {
+      "name": "sdl2-ttf",
+      "platform": "!android"
+    },
+    {
+      "name": "glew",
+      "platform": "!android"
+    },
     "spdlog",
-    { "name": "nlohmann-json", "version>=" : "3.11.3" },
+    {
+      "name": "nlohmann-json",
+      "version>=": "3.11.3"
+    },
     "glm",
-
     "tinyxml2",
-
-    { "name": "gtest", "platform": "!android" }
+    {
+      "name": "gtest",
+      "platform": "!android"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- update vcpkg.json with builtin-baseline
- document baseline usage in README

## Testing
- `cmake -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685c187ae5c883249b134ffe7ab0afb5