### PR TITLE
Fix missing vcpkg baseline for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
           fi
           ./bootstrap-vcpkg.sh -disableMetrics
         shell: bash
+      - name: Fetch full vcpkg history
+        run: |
+          git -C vcpkg fetch --prune --progress --depth=1000
+        shell: bash
 
       - name: Install vcpkg dependencies
         run: |
@@ -197,6 +201,10 @@ jobs:
             git pull
           fi
           ./bootstrap-vcpkg.sh -disableMetrics
+        shell: bash
+      - name: Fetch full vcpkg history
+        run: |
+          git -C vcpkg fetch --prune --progress --depth=1000
         shell: bash
 
       - name: Install vcpkg dependencies for Android

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "promethean-engine",
   "version-string": "0.1.0",
   "description": "Minimal 2D engine using SDL2",
-  "builtin-baseline": "f5ca1a1e2b8f6bc59f2a5b4c4b8ab0d3e7f2d5a0",
+  "builtin-baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0",
   "dependencies": [
     "sdl2",
     {


### PR DESCRIPTION
## Summary
- update builtin baseline to latest vcpkg tag
- fetch more vcpkg history in CI so baseline commit is present

## Testing
- `cmake --version`
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685d32494da48324aa2608df7788d51e