### PR TITLE
Fix Android char8_t build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sudo apt update && sudo apt install -y \
   libsdl2-mixer-dev \
   libgl1-mesa-dev \
   libsqlite3-dev \
-  libnlohmann-json-dev (>=3.11.3) \
+  libnlohmann-json-dev (>=3.12.0) \
   lcov
 
 mkdir -p build && cd build

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,7 +24,7 @@
     "spdlog",
     {
       "name": "nlohmann-json",
-      "version>=": "3.11.3"
+      "version>=": "3.12.0"
     },
     "glm",
     "tinyxml2",


### PR DESCRIPTION
## Summary
- upgrade nlohmann-json to 3.12 to fix Android char8_t issue

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685d36e8ef8083248c5ca8c120c3ba4e