### PR TITLE
Fix Android char8_t crash with overlay patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Fetch full vcpkg history
         run: |
           git -C vcpkg fetch --prune --progress --depth=1000
+          git -C vcpkg fetch --all --tags
         shell: bash
 
       - name: Install vcpkg dependencies
@@ -205,6 +206,7 @@ jobs:
       - name: Fetch full vcpkg history
         run: |
           git -C vcpkg fetch --prune --progress --depth=1000
+          git -C vcpkg fetch --all --tags
         shell: bash
 
       - name: Install vcpkg dependencies for Android
@@ -217,6 +219,7 @@ jobs:
           ANDROID_NDK_HOME: ${{ env.ANDROID_NDK_HOME }}
           VCPKG_CMAKE_SYSTEM_NAME: Android
           VCPKG_FEATURE_FLAGS: manifests
+          VCPKG_OVERLAY_PORTS: "${{ github.workspace }}/overlays/nlohmann-json-android-fix"
 
       - name: Configure CMake for Android
         run: |
@@ -229,6 +232,7 @@ jobs:
             -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE="$ANDROID_TOOLCHAIN_FILE" \
             -DVCPKG_TARGET_TRIPLET="$TRIPLET" \
             -DVCPKG_INSTALLED_DIR="${{ github.workspace }}/vcpkg_installed" \
+            -DVCPKG_OVERLAY_PORTS="${{ github.workspace }}/overlays/nlohmann-json-android-fix" \
             -DANDROID_ABI="${{ matrix.abi }}" \
             -DANDROID_PLATFORM=android-21 \
             -DANDROID_STL=c++_shared \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ endif()
 #                Spécificités de la cible Android
 # ====================================================================
 if(ANDROID)
-    target_compile_definitions(engine PRIVATE PROMETHEAN_ANDROID GRAPHICS_API_GLES)
+    target_compile_definitions(engine PRIVATE PROMETHEAN_ANDROID GRAPHICS_API_GLES JSON_ANDROID_CHAR8T_HACK)
 
     find_package(SDL2_mixer CONFIG REQUIRED)
 

--- a/overlays/nlohmann-json-android-fix/portfile.cmake
+++ b/overlays/nlohmann-json-android-fix/portfile.cmake
@@ -1,0 +1,56 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nlohmann/json
+    REF v3.12.0
+    SHA512 6cc1e86261f8fac21cc17a33da3b6b3c3cd5c116755651642af3c9e99bb3538fd42c1bd50397a77c8fb6821bc62d90e6b91bcdde77a78f58f2416c62fc53b97d
+    HEAD_REF master
+)
+
+if(VCPKG_TARGET_IS_ANDROID)
+    file(READ "${SOURCE_PATH}/single_include/nlohmann/json.hpp" _json_hpp)
+    string(REPLACE "#ifdef JSON_HAS_CPP_20\n    p = std_fs::path(std::u8string_view(reinterpret_cast<const char8_t*>(s.data()), s.size()));\n#else\n    p = std_fs::u8path(s); // accepts UTF-8 encoded std::string in C++17, deprecated in C++20\n#endif" "#if JSON_ANDROID_CHAR8T_HACK\n    p = std_fs::u8path(s);\n#elif defined(JSON_HAS_CPP_20)\n    p = std_fs::path(std::u8string_view(reinterpret_cast<const char8_t*>(s.data()), s.size()));\n#else\n    p = std_fs::u8path(s); // accepts UTF-8 encoded std::string in C++17, deprecated in C++20\n#endif" _json_hpp)
+    string(REPLACE "#ifdef JSON_HAS_CPP_20\n    const std::u8string s = p.u8string();\n    j = std::string(s.begin(), s.end());\n#else\n    j = p.u8string(); // returns std::string in C++17\n#endif" "#if JSON_ANDROID_CHAR8T_HACK\n    j = p.u8string();\n#elif defined(JSON_HAS_CPP_20)\n    const std::u8string s = p.u8string();\n    j = std::string(s.begin(), s.end());\n#else\n    j = p.u8string(); // returns std::string in C++17\n#endif" _json_hpp)
+    file(WRITE "${SOURCE_PATH}/single_include/nlohmann/json.hpp" "${_json_hpp}")
+endif()
+
+if(NOT DEFINED nlohmann-json_IMPLICIT_CONVERSIONS)
+    set(nlohmann-json_IMPLICIT_CONVERSIONS ON)
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+FEATURES
+    "diagnostics"           JSON_Diagnostics
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+        -DJSON_Install=ON
+        -DJSON_MultipleHeaders=ON
+        -DJSON_BuildTests=OFF
+        -DJSON_ImplicitConversions=${nlohmann-json_IMPLICIT_CONVERSIONS}
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "nlohmann_json" CONFIG_PATH "share/cmake/nlohmann_json")
+vcpkg_fixup_pkgconfig()
+
+vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/share/nlohmann_json/nlohmann_jsonTargets.cmake"
+    "{_IMPORT_PREFIX}/nlohmann_json.natvis"
+    "{_IMPORT_PREFIX}/share/nlohmann_json/nlohmann_json.natvis"
+    IGNORE_UNCHANGED
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/nlohmann_json.natvis")
+    file(RENAME
+        "${CURRENT_PACKAGES_DIR}/nlohmann_json.natvis"
+        "${CURRENT_PACKAGES_DIR}/share/nlohmann_json/nlohmann_json.natvis"
+    )
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.MIT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# Handle usage
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/overlays/nlohmann-json-android-fix/usage
+++ b/overlays/nlohmann-json-android-fix/usage
@@ -1,0 +1,12 @@
+The package nlohmann-json provides CMake targets:
+
+    find_package(nlohmann_json CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE nlohmann_json::nlohmann_json)
+
+The package nlohmann-json can be configured to not provide implicit conversions via a custom triplet file:
+
+    set(nlohmann-json_IMPLICIT_CONVERSIONS OFF)
+
+For more information, see the docs here:
+    
+    https://json.nlohmann.me/api/macros/json_use_implicit_conversions/

--- a/overlays/nlohmann-json-android-fix/vcpkg.json
+++ b/overlays/nlohmann-json-android-fix/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "nlohmann-json",
+  "version-semver": "3.12.0",
+  "description": "JSON for Modern C++",
+  "homepage": "https://github.com/nlohmann/json",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "diagnostics": {
+      "description": "Build json_diagnostics"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Android-specific overlay for nlohmann-json 3.12.0
- inject JSON_ANDROID_CHAR8T_HACK define when building for Android
- use overlay in CI Android job and fetch all vcpkg tags

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685d555ddcec83248045ace45d6e2310