### PR TITLE
Fix Android json path support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,9 @@ endif()
 #                Spécificités de la cible Android
 # ====================================================================
 if(ANDROID)
-    target_compile_definitions(engine PRIVATE PROMETHEAN_ANDROID GRAPHICS_API_GLES JSON_ANDROID_CHAR8T_HACK)
+    target_compile_definitions(engine PRIVATE PROMETHEAN_ANDROID GRAPHICS_API_GLES)
+    target_sources(engine PUBLIC src/compat/json_android_fix.h)
+    target_compile_definitions(engine PUBLIC JSON_ANDROID_FIX=1)
 
     find_package(SDL2_mixer CONFIG REQUIRED)
 

--- a/src/compat/json_android_fix.h
+++ b/src/compat/json_android_fix.h
@@ -1,0 +1,21 @@
+#pragma once
+#ifdef __ANDROID__
+#include <nlohmann/json.hpp>
+#include <filesystem>
+
+// Disable C++20 detection for json in this translation unit
+#undef JSON_HAS_CPP_20
+#define JSON_HAS_CPP_20 0
+
+namespace nlohmann {
+    template<>
+    struct adl_serializer<std::filesystem::path> {
+        static void to_json(json& j, const std::filesystem::path& p) {
+            j = p.u8string();
+        }
+        static void from_json(const json& j, std::filesystem::path& p) {
+            p = std::filesystem::path(j.get<std::string>());
+        }
+    };
+}
+#endif // __ANDROID__


### PR DESCRIPTION
## Summary
- avoid nlohmann::json C++20 path conversion on Android
- expose shim header when building for Android

## Testing
- `cmake .. -G Ninja`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: RuntimeOverlay.AudioSlider_ChangesVolume, AudioEngine.Init, AudioEngine.PlaySound_ChannelsDifferent, AudioEngine.MasterVolume, AudioEngine.NoFileWrites, AudioEngine.EventBusPublished, AudioEngine.StopAll, AudioBus.DefaultState, AudioBus.SetGetVolume, AudioBus.MuteState, AudioBus.FadeOutEmptyBus)*

------
https://chatgpt.com/codex/tasks/task_e_685d66cb90a083249d8124cd83cdf0bc