### PR TITLE
Fix Android INTERFACE_SOURCES warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,8 @@ endif()
 # ====================================================================
 if(ANDROID)
     target_compile_definitions(engine PRIVATE PROMETHEAN_ANDROID GRAPHICS_API_GLES)
-    target_sources(engine PUBLIC src/compat/json_android_fix.h)
+    target_include_directories(engine PRIVATE src/compat)
+    target_sources(engine PRIVATE src/compat/json_android_fix.h)
     target_compile_definitions(engine PUBLIC JSON_ANDROID_FIX=1)
 
     find_package(SDL2_mixer CONFIG REQUIRED)


### PR DESCRIPTION
## Summary
- stop propagating json shim header to dependants
- add compat folder include path for Android

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685d6a5552508324a41411cf580fb6f4