### PR TITLE
Fix Android build by patching nlohmann JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,9 @@ jobs:
           VCPKG_CMAKE_SYSTEM_NAME: Android
           VCPKG_FEATURE_FLAGS: manifests
 
+      - name: Patch nlohmann-json for char8_t
+        run: ./scripts/patch-json-android.sh
+
       - name: Configure CMake for Android
         run: |
           TRIPLET="arm64-android"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
 # Repo Notes
 
-- The workaround for nlohmann-json's char8_t issue has been removed since version 3.12 works on all platforms.
+- The workaround for nlohmann-json's `char8_t` issue was removed because version 3.12 supposedly works on all platforms.
+- Android builds with NDK r25 still fail due to `std::filesystem::path::u8string()` returning `std::string`.
+- A conditional patch is reintroduced in `scripts/patch-json-android.sh` and applied during the Android CI job after vcpkg installation.

--- a/scripts/patch-json-android.sh
+++ b/scripts/patch-json-android.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE="vcpkg_installed/arm64-android/include/nlohmann/detail/conversions/to_json.hpp"
+
+if [ ! -f "$FILE" ]; then
+    echo "File $FILE not found" >&2
+    exit 1
+fi
+
+if grep -q "__cpp_lib_char8_t" "$FILE"; then
+    echo "nlohmann::json patch already applied"
+    exit 0
+fi
+
+# Replace the incompatible line with conditional code
+sed -i 's|const std::u8string s = p.u8string();|\
+#if defined(__cpp_lib_char8_t)\
+const std::u8string u8s = p.u8string();\
+j = std::string(reinterpret_cast<const char*>(u8s.data()), u8s.size());\
+#else\
+const std::string s = p.u8string();\
+j = s;\
+#endif|' "$FILE"
+
+# Verify patch
+if grep -q "__cpp_lib_char8_t" "$FILE"; then
+    echo "✅ nlohmann::json patched for Android char8_t"
+else
+    echo "❌ Failed to patch nlohmann::json" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- patch nlohmann JSON for char8_t on Android
- call patch script from the Android workflow
- document the workaround in AGENTS.md

## Testing
- `./scripts/patch-json-android.sh`
- `./vcpkg/vcpkg install --x-manifest-root=temp_manifest --x-install-root=./vcpkg_installed` *(failed: BUILD_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_685e6bd7b1b4832499a6b031a809c18f