### PR TITLE
Fix Android char8_t build issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,4 @@
 # Repo Notes
 
-- The workaround for nlohmann-json's `char8_t` issue was removed because version 3.12 supposedly works on all platforms.
-- Android builds with NDK r25 still fail due to `std::filesystem::path::u8string()` returning `std::string`.
-- A conditional patch is reintroduced in `scripts/patch-json-android.sh` and applied during the Android CI job after vcpkg installation.
+- Version 3.12 of nlohmann-json still breaks on Android because `std::filesystem::path::u8string()` returns `std::string` when compiling with C++17.
+- We define `JSON_HAS_FILESYSTEM 1` before including `<nlohmann/json.hpp>` and patch the generated `to_json.hpp` via `scripts/patch-json-android.sh` after `vcpkg install`.

--- a/src/audio/AudioSettings.h
+++ b/src/audio/AudioSettings.h
@@ -1,4 +1,5 @@
 #pragma once
+#define JSON_HAS_FILESYSTEM 1
 #include <nlohmann/json.hpp>
 #include <SDL_mixer.h>
 #include <string>


### PR DESCRIPTION
## Summary
- document conditional patch for `char8_t` on Android
- enable `<filesystem>` for nlohmann-json when reading audio settings

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e981209f88324a87f68a064b19382