### PR TITLE
fix(android): patch nlohmann json char8_t issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Version 3.12 of nlohmann-json still breaks on Android because `std::filesystem::path::u8string()` returns `std::string` when compiling with C++17.
 - We define `JSON_HAS_FILESYSTEM 1` before including `<nlohmann/json.hpp>` and patch the generated `to_json.hpp` via `scripts/patch-json-android.sh` after `vcpkg install`.
+- The script replaces the `std::u8string` block with a cross-platform version using `auto s = p.u8string();` and `std::string(reinterpret_cast<const char*>(s.data()), s.size())`. Any upstream changes in nlohmann-json may require updating the patch.

--- a/scripts/patch-json-android.sh
+++ b/scripts/patch-json-android.sh
@@ -8,23 +8,19 @@ if [ ! -f "$FILE" ]; then
     exit 1
 fi
 
-if grep -q "__cpp_lib_char8_t" "$FILE"; then
+if grep -q "reinterpret_cast<const char*" "$FILE"; then
     echo "nlohmann::json patch already applied"
     exit 0
 fi
 
-# Replace the incompatible line with conditional code
-sed -i 's|const std::u8string s = p.u8string();|\
-#if defined(__cpp_lib_char8_t)\
-const std::u8string u8s = p.u8string();\
-j = std::string(reinterpret_cast<const char*>(u8s.data()), u8s.size());\
-#else\
-const std::string s = p.u8string();\
-j = s;\
-#endif|' "$FILE"
+perl -0pi -e '
+    s/#ifdef JSON_HAS_CPP_20\n//s;
+    s/\n#else\n\s*j = p\.u8string\(\); \/\/ returns std::string in C\+\+17\n#endif//s;
+    s/const std::u8string\s+[a-zA-Z0-9_]*\s*=\s*p\.u8string\(\);/auto s = p.u8string();/s;
+    s/j = std::string\(s.begin\(\), s.end\(\)\);/j = std::string(reinterpret_cast<const char*>(s.data()), s.size());/s;
+' "$FILE"
 
-# Verify patch
-if grep -q "__cpp_lib_char8_t" "$FILE"; then
+if grep -q "reinterpret_cast<const char*" "$FILE"; then
     echo "✅ nlohmann::json patched for Android char8_t"
 else
     echo "❌ Failed to patch nlohmann::json" >&2


### PR DESCRIPTION
## Summary
- fix `scripts/patch-json-android.sh` to rewrite the `u8string()` handling for Android
- document char8_t patch in `AGENTS.md`

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685e9da7058c8324891d82dc45a50dc2