### PR TITLE
Fix vcpkg baseline missing

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "promethean-engine",
   "version-string": "0.1.0",
+  "builtin-baseline": "7066011e27c97dbcfff739be2b69b592a41fc74a",
   "description": "Minimal 2D engine using SDL2",
   "dependencies": [
     "sdl2",


### PR DESCRIPTION
## Summary
- add the required `builtin-baseline` field to `vcpkg.json` so vcpkg's versioning works properly

## Testing
- `cmake --version`
- `cmake -B build -S .` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_685eaa7b1d748324a98ddb58cf0246bb