### PR TITLE
Add minimal A* pathfinding system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,10 @@ add_library(engine
     src/physics/CollisionLayer.cpp     src/physics/CollisionLayer.h
     # ── AI -------------------------------------------------------------------
     src/ai/Pathfinder.cpp              src/ai/Pathfinder.h
+    # ── Pathfinding ---------------------------------------------------------
+    src/pathfinding/AStar.cpp          src/pathfinding/AStar.h
+    src/ecs/NavComponent.cpp           src/ecs/NavComponent.h
+    src/ecs/PathfindingSystem.cpp      src/ecs/PathfindingSystem.h
     # ── Settings -------------------------------------------------------------
     src/core/SettingsManager.cpp       src/core/SettingsManager.h
 )
@@ -289,6 +293,8 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/audio/TestAudioEngine.cpp
         tests/audio/TestAudioBus.cpp
         tests/ecs/TestECS.cpp
+        tests/pathfinding/TestAStar.cpp
+        tests/ecs/TestPathfindingSystem.cpp
     )
 
     file(GLOB TEST_AUDIO_FILES

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,13 @@ gère la création et destruction d'entités ainsi que l'attachement de
 composants. Les `System` parcourent les entités ayant un ensemble de
 composants précis et mettent à jour leur logique chaque frame.
 
+## Pathfinding
+
+Un module minimal d'**A\*** calcule des chemins sur une grille 2D. Le
+`NavComponent` stocke la position courante, la destination et le chemin
+résultant. Le `PathfindingSystem` actualise ces entités à chaque tick en
+avançant vers la cellule suivante.
+
 ## Debug & ImGui
 
 Un overlay de debug basé sur **Dear ImGui** est intégré pour profiler et

--- a/src/ecs/NavComponent.h
+++ b/src/ecs/NavComponent.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <glm/vec2.hpp>
+#include <vector>
+
+namespace pe::ecs {
+
+struct NavComponent {
+    glm::ivec2 position{};       ///< current cell
+    glm::ivec2 destination{};    ///< goal cell
+    std::vector<glm::ivec2> path;///< computed path
+    size_t current{0};           ///< current step index
+};
+
+} // namespace pe::ecs

--- a/src/ecs/PathfindingSystem.cpp
+++ b/src/ecs/PathfindingSystem.cpp
@@ -1,0 +1,25 @@
+#include "ecs/PathfindingSystem.h"
+#include "ecs/Registry.h"
+
+namespace pe::ecs {
+
+PathfindingSystem::PathfindingSystem(Registry& reg, const pathfinding::Grid* grid)
+    : System(reg), m_grid(grid) {}
+
+void PathfindingSystem::Update(float)
+{
+    if(!m_grid) return;
+    registry().for_each<NavComponent>([&](NavComponent& nav){
+        if(nav.position == nav.destination) return;
+        if(nav.path.empty() || nav.current >= nav.path.size()) {
+            nav.path = pathfinding::FindPath(*m_grid, nav.position, nav.destination);
+            nav.current = nav.path.empty() ? 0 : 1; // skip starting cell
+        }
+        if(!nav.path.empty() && nav.current < nav.path.size()) {
+            nav.position = nav.path[nav.current];
+            ++nav.current;
+        }
+    });
+}
+
+} // namespace pe::ecs

--- a/src/ecs/PathfindingSystem.h
+++ b/src/ecs/PathfindingSystem.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "ecs/System.h"
+#include "pathfinding/AStar.h"
+#include "ecs/NavComponent.h"
+
+namespace pe::ecs {
+
+class PathfindingSystem : public System {
+public:
+    PathfindingSystem(Registry& reg, const pathfinding::Grid* grid);
+
+    void Update(float dt) override;
+    void SetGrid(const pathfinding::Grid* grid) { m_grid = grid; }
+
+private:
+    const pathfinding::Grid* m_grid{nullptr};
+};
+
+} // namespace pe::ecs

--- a/src/ecs/Registry.cpp
+++ b/src/ecs/Registry.cpp
@@ -24,6 +24,7 @@ void Registry::destroy(EntityID id) {
     m_positions.remove(id);
     m_velocities.remove(id);
     m_renderables.remove(id);
+    m_navs.remove(id);
     m_free.push_back(id);
 }
 

--- a/src/ecs/Registry.h
+++ b/src/ecs/Registry.h
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include "ecs/Component.h"
 #include "ecs/Entity.h"
+#include "ecs/NavComponent.h"
 
 namespace pe::ecs {
 
@@ -38,6 +39,7 @@ private:
     ComponentPool<Position>   m_positions;
     ComponentPool<Velocity>   m_velocities;
     ComponentPool<Renderable> m_renderables;
+    ComponentPool<NavComponent> m_navs;
 
     template<typename C>
     ComponentPool<C>& pool();
@@ -74,6 +76,7 @@ inline ComponentPool<C>& Registry::pool() {
     if constexpr (std::is_same_v<C, Position>) return m_positions;
     else if constexpr (std::is_same_v<C, Velocity>) return m_velocities;
     else if constexpr (std::is_same_v<C, Renderable>) return m_renderables;
+    else if constexpr (std::is_same_v<C, NavComponent>) return m_navs;
 }
 
 template<typename C>
@@ -81,6 +84,7 @@ inline const ComponentPool<C>& Registry::pool() const {
     if constexpr (std::is_same_v<C, Position>) return m_positions;
     else if constexpr (std::is_same_v<C, Velocity>) return m_velocities;
     else if constexpr (std::is_same_v<C, Renderable>) return m_renderables;
+    else if constexpr (std::is_same_v<C, NavComponent>) return m_navs;
 }
 
 inline size_t Registry::active() const {

--- a/src/ecs/ecs.h
+++ b/src/ecs/ecs.h
@@ -3,3 +3,5 @@
 #include "ecs/Component.h"
 #include "ecs/Registry.h"
 #include "ecs/System.h"
+#include "ecs/NavComponent.h"
+#include "ecs/PathfindingSystem.h"

--- a/src/pathfinding/AStar.cpp
+++ b/src/pathfinding/AStar.cpp
@@ -1,0 +1,94 @@
+#include "pathfinding/AStar.h"
+#include <algorithm>
+#include <cmath>
+
+namespace pe::pathfinding {
+
+namespace {
+inline int Heuristic(const glm::ivec2& a, const glm::ivec2& b) {
+    return std::abs(a.x - b.x) + std::abs(a.y - b.y);
+}
+
+inline int Index(int x, int y, int w) { return y * w + x; }
+}
+
+std::vector<glm::ivec2> FindPath(const Grid& grid, const glm::ivec2& start, const glm::ivec2& goal)
+{
+    std::vector<glm::ivec2> result;
+    if(grid.empty() || grid[0].empty()) return result;
+    int width = static_cast<int>(grid[0].size());
+    int height = static_cast<int>(grid.size());
+    auto valid = [&](const glm::ivec2& p){
+        return p.x >=0 && p.y >=0 && p.x < width && p.y < height && grid[p.y][p.x] == 0;
+    };
+    if(!valid(start) || !valid(goal)) return result;
+
+    std::vector<Node> nodes(static_cast<size_t>(width*height));
+    std::vector<int> heap; heap.reserve(nodes.size());
+
+    int startIdx = Index(start.x,start.y,width);
+    Node& s = nodes[startIdx];
+    s.pos = start; s.g = 0; s.f = Heuristic(start, goal); s.inOpen = true;
+    heap.push_back(startIdx);
+
+    const glm::ivec2 dirs[4] = {{1,0},{-1,0},{0,1},{0,-1}};
+
+    auto heap_push = [&](int idx){
+        heap.push_back(idx);
+        size_t i = heap.size()-1;
+        while(i>0){
+            size_t p=(i-1)/2;
+            if(nodes[heap[p]].f <= nodes[heap[i]].f) break;
+            std::swap(heap[p],heap[i]);
+            i=p;
+        }
+    };
+
+    auto heap_pop = [&](){
+        int idx = heap.front();
+        heap[0] = heap.back();
+        heap.pop_back();
+        size_t i=0;
+        while(true){
+            size_t l=2*i+1, r=l+1;
+            if(l>=heap.size()) break;
+            size_t smallest=l;
+            if(r<heap.size() && nodes[heap[r]].f < nodes[heap[l]].f) smallest=r;
+            if(nodes[heap[i]].f <= nodes[heap[smallest]].f) break;
+            std::swap(heap[i],heap[smallest]);
+            i=smallest;
+        }
+        return idx;
+    };
+
+    while(!heap.empty()) {
+        int currentIdx = heap_pop();
+        Node& current = nodes[currentIdx];
+        current.inOpen=false; current.closed=true;
+        if(current.pos==goal){
+            int idx=currentIdx;
+            while(idx!=-1){
+                result.push_back(nodes[idx].pos);
+                idx=nodes[idx].parent;
+                if(result.size()>1024) break;
+            }
+            std::reverse(result.begin(), result.end());
+            return result;
+        }
+        for(auto d:dirs){
+            glm::ivec2 np=current.pos+d;
+            if(!valid(np)) continue;
+            int ni=Index(np.x,np.y,width);
+            Node& n=nodes[ni];
+            if(n.closed) continue;
+            int tentative = current.g + 1;
+            if(!n.inOpen || tentative < n.g){
+                n.pos=np; n.g=tentative; n.f=tentative+Heuristic(np,goal); n.parent=currentIdx;
+                if(!n.inOpen){ heap_push(ni); n.inOpen=true; }
+            }
+        }
+    }
+    return result; // empty = no path
+}
+
+} // namespace pe::pathfinding

--- a/src/pathfinding/AStar.h
+++ b/src/pathfinding/AStar.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <glm/vec2.hpp>
+#include <vector>
+
+namespace pe::pathfinding {
+
+using Grid = std::vector<std::vector<int>>;
+
+struct Node {
+    glm::ivec2 pos{};
+    int g{0};
+    int f{0};
+    int parent{-1};
+    bool inOpen{false};
+    bool closed{false};
+};
+
+std::vector<glm::ivec2> FindPath(const Grid& grid, const glm::ivec2& start, const glm::ivec2& goal);
+
+} // namespace pe::pathfinding

--- a/tests/ecs/TestPathfindingSystem.cpp
+++ b/tests/ecs/TestPathfindingSystem.cpp
@@ -1,0 +1,23 @@
+#include "ecs/PathfindingSystem.h"
+#include "ecs/Registry.h"
+#include <gtest/gtest.h>
+
+using namespace pe::ecs;
+using namespace pe::pathfinding;
+
+TEST(PathfindingSystem, MoveAlongPath)
+{
+    Grid grid(1, std::vector<int>{0,0,0});
+    Registry reg;
+    auto e = reg.create();
+    auto& nav = reg.add<NavComponent>(e.id());
+    nav.position = {0,0};
+    nav.destination = {2,0};
+    PathfindingSystem sys(reg, &grid);
+    sys.Update(0.f); // compute path and move to first step
+    EXPECT_EQ(nav.position, glm::ivec2(1,0));
+    sys.Update(0.f);
+    EXPECT_EQ(nav.position, glm::ivec2(2,0));
+    sys.Update(0.f);
+    EXPECT_EQ(nav.position, glm::ivec2(2,0));
+}

--- a/tests/pathfinding/TestAStar.cpp
+++ b/tests/pathfinding/TestAStar.cpp
@@ -1,0 +1,29 @@
+#include "pathfinding/AStar.h"
+#include <gtest/gtest.h>
+
+using namespace pe::pathfinding;
+
+TEST(AStar, StraightLine)
+{
+    Grid grid(1, std::vector<int>(5,0));
+    auto path = FindPath(grid, {0,0}, {4,0});
+    ASSERT_EQ(path.size(), 5u);
+    EXPECT_EQ(path.front(), glm::ivec2(0,0));
+    EXPECT_EQ(path.back(), glm::ivec2(4,0));
+}
+
+TEST(AStar, AvoidObstacle)
+{
+    Grid grid(3, std::vector<int>(3,0));
+    grid[1][1] = 1; // obstacle
+    auto path = FindPath(grid, {0,1}, {2,1});
+    ASSERT_EQ(path.size(), 5u); // around obstacle
+    EXPECT_EQ(path.back(), glm::ivec2(2,1));
+}
+
+TEST(AStar, NoPath)
+{
+    Grid grid(1, std::vector<int>{0,1,0});
+    auto path = FindPath(grid, {0,0}, {2,0});
+    EXPECT_TRUE(path.empty());
+}


### PR DESCRIPTION
## Summary
- implement grid based A* in new module
- add NavComponent and PathfindingSystem to ECS
- document pathfinding in architecture guide
- provide unit tests for solver and ECS integration

## Testing
- `cmake -S . -B build-debug`
- `cmake --build build-debug`
- `cd build-debug && ctest -R Pathfinding --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685eb2f9c8dc8324b4e3054439c71d79