### PR TITLE
Add minimal Behavior System

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ add_library(engine
     src/pathfinding/AStar.cpp          src/pathfinding/AStar.h
     src/ecs/NavComponent.cpp           src/ecs/NavComponent.h
     src/ecs/PathfindingSystem.cpp      src/ecs/PathfindingSystem.h
+    src/ecs/BehaviorComponent.cpp      src/ecs/BehaviorComponent.h
+    src/ecs/BehaviorSystem.cpp         src/ecs/BehaviorSystem.h
     # ── Settings -------------------------------------------------------------
     src/core/SettingsManager.cpp       src/core/SettingsManager.h
     # ── Save ---------------------------------------------------------------
@@ -297,6 +299,7 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/ecs/TestECS.cpp
         tests/pathfinding/TestAStar.cpp
         tests/ecs/TestPathfindingSystem.cpp
+        tests/ecs/TestBehaviorSystem.cpp
         tests/save/TestSaveManager.cpp
     )
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,14 @@ Un module minimal d'**A\*** calcule des chemins sur une grille 2D. Le
 résultant. Le `PathfindingSystem` actualise ces entités à chaque tick en
 avançant vers la cellule suivante.
 
+## Behavior
+
+Un **BehaviorSystem** minimal gère l'IA des entités via une petite machine à
+états. Le `BehaviorComponent` stocke l'état courant (Idle, Seek…) ainsi que les
+paramètres de transition. Chaque tick, le système met à jour la minuterie et fait
+évoluer l'état, par exemple en déplaçant l'entité vers une cible lorsque l'état
+`Seek` est actif.
+
 ## Debug & ImGui
 
 Un overlay de debug basé sur **Dear ImGui** est intégré pour profiler et

--- a/src/ecs/BehaviorComponent.cpp
+++ b/src/ecs/BehaviorComponent.cpp
@@ -1,0 +1,27 @@
+#include "ecs/BehaviorComponent.h"
+
+namespace pe::ecs {
+
+nlohmann::json BehaviorComponent::ToJSON() const {
+    nlohmann::json j;
+    j["state"] = static_cast<int>(state);
+    j["target"] = { {"x", target.x}, {"y", target.y} };
+    j["timer"] = timer;
+    j["idleDuration"] = idleDuration;
+    j["speed"] = speed;
+    return j;
+}
+
+void BehaviorComponent::FromJSON(const nlohmann::json& j) {
+    state = static_cast<BehaviorState>(j.value("state", 0));
+    if(j.contains("target")) {
+        const auto& t = j["target"];
+        target.x = t.value("x", 0.f);
+        target.y = t.value("y", 0.f);
+    }
+    timer = j.value("timer", 0.f);
+    idleDuration = j.value("idleDuration", 1.f);
+    speed = j.value("speed", 1.f);
+}
+
+} // namespace pe::ecs

--- a/src/ecs/BehaviorComponent.h
+++ b/src/ecs/BehaviorComponent.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "ecs/Component.h"
+#include <glm/vec2.hpp>
+#define JSON_HAS_FILESYSTEM 1
+#include <nlohmann/json.hpp>
+
+namespace pe::ecs {
+
+enum class BehaviorState { Idle = 0, Seek, Flee, Patrol };
+
+struct BehaviorComponent {
+    BehaviorState state{BehaviorState::Idle};
+    glm::vec2 target{0.f, 0.f};
+    float timer{0.f};
+    float idleDuration{1.f};
+    float speed{1.f};
+
+    nlohmann::json ToJSON() const;
+    void FromJSON(const nlohmann::json& j);
+};
+
+} // namespace pe::ecs

--- a/src/ecs/BehaviorSystem.cpp
+++ b/src/ecs/BehaviorSystem.cpp
@@ -1,0 +1,36 @@
+#include "ecs/BehaviorSystem.h"
+#include "ecs/Registry.h"
+#include <glm/glm.hpp>
+
+namespace pe::ecs {
+
+void BehaviorSystem::Update(float dt) {
+    registry().for_each<BehaviorComponent, Position>([dt](BehaviorComponent& beh, Position& pos) {
+        switch(beh.state) {
+        case BehaviorState::Idle:
+            beh.timer += dt;
+            if(beh.timer >= beh.idleDuration) {
+                beh.timer = 0.f;
+                beh.state = BehaviorState::Seek;
+            }
+            break;
+        case BehaviorState::Seek: {
+            glm::vec2 cur{pos.x, pos.y};
+            glm::vec2 dir = beh.target - cur;
+            float dist = glm::length(dir);
+            if(dist < 0.1f) {
+                beh.state = BehaviorState::Idle;
+                beh.timer = 0.f;
+            } else if(dist > 0.f) {
+                dir /= dist;
+                pos.x += dir.x * beh.speed * dt;
+                pos.y += dir.y * beh.speed * dt;
+            }
+            break;
+        }
+        default: break;
+        }
+    });
+}
+
+} // namespace pe::ecs

--- a/src/ecs/BehaviorSystem.h
+++ b/src/ecs/BehaviorSystem.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "ecs/System.h"
+#include "ecs/BehaviorComponent.h"
+#include "ecs/Component.h"
+
+namespace pe::ecs {
+
+class BehaviorSystem : public System {
+public:
+    explicit BehaviorSystem(Registry& reg) : System(reg) {}
+    void Update(float dt) override;
+};
+
+} // namespace pe::ecs

--- a/src/ecs/Registry.cpp
+++ b/src/ecs/Registry.cpp
@@ -25,6 +25,7 @@ void Registry::destroy(EntityID id) {
     m_velocities.remove(id);
     m_renderables.remove(id);
     m_navs.remove(id);
+    m_behaviors.remove(id);
     m_free.push_back(id);
 }
 

--- a/src/ecs/Registry.h
+++ b/src/ecs/Registry.h
@@ -7,6 +7,7 @@
 #include "ecs/Component.h"
 #include "ecs/Entity.h"
 #include "ecs/NavComponent.h"
+#include "ecs/BehaviorComponent.h"
 
 namespace Promethean { class SaveManager; }
 
@@ -44,6 +45,7 @@ private:
     ComponentPool<Velocity>   m_velocities;
     ComponentPool<Renderable> m_renderables;
     ComponentPool<NavComponent> m_navs;
+    ComponentPool<BehaviorComponent> m_behaviors;
 
     template<typename C>
     ComponentPool<C>& pool();
@@ -81,6 +83,7 @@ inline ComponentPool<C>& Registry::pool() {
     else if constexpr (std::is_same_v<C, Velocity>) return m_velocities;
     else if constexpr (std::is_same_v<C, Renderable>) return m_renderables;
     else if constexpr (std::is_same_v<C, NavComponent>) return m_navs;
+    else if constexpr (std::is_same_v<C, BehaviorComponent>) return m_behaviors;
 }
 
 template<typename C>
@@ -89,6 +92,7 @@ inline const ComponentPool<C>& Registry::pool() const {
     else if constexpr (std::is_same_v<C, Velocity>) return m_velocities;
     else if constexpr (std::is_same_v<C, Renderable>) return m_renderables;
     else if constexpr (std::is_same_v<C, NavComponent>) return m_navs;
+    else if constexpr (std::is_same_v<C, BehaviorComponent>) return m_behaviors;
 }
 
 inline size_t Registry::active() const {

--- a/src/ecs/ecs.h
+++ b/src/ecs/ecs.h
@@ -5,3 +5,5 @@
 #include "ecs/System.h"
 #include "ecs/NavComponent.h"
 #include "ecs/PathfindingSystem.h"
+#include "ecs/BehaviorComponent.h"
+#include "ecs/BehaviorSystem.h"

--- a/src/save/SaveManager.cpp
+++ b/src/save/SaveManager.cpp
@@ -24,6 +24,10 @@ nlohmann::json SaveManager::Serialize(const Registry& reg, Entity entity) {
         const auto* c = reg.pool<NavComponent>().try_get(entity.id());
         j["NavComponent"] = c->ToJSON();
     }
+    if(reg.has<BehaviorComponent>(entity.id())) {
+        const auto* c = reg.pool<BehaviorComponent>().try_get(entity.id());
+        j["BehaviorComponent"] = c->ToJSON();
+    }
     return j;
 }
 
@@ -44,6 +48,10 @@ void SaveManager::Deserialize(Registry& reg, Entity entity, const nlohmann::json
         auto& c = reg.add<NavComponent>(entity.id());
         c.FromJSON(*it);
     }
+    if(auto it = data.find("BehaviorComponent"); it != data.end()) {
+        auto& c = reg.add<BehaviorComponent>(entity.id());
+        c.FromJSON(*it);
+    }
 }
 
 bool SaveManager::SaveToFile(const std::string& path, const Registry& reg) {
@@ -54,6 +62,7 @@ bool SaveManager::SaveToFile(const std::string& path, const Registry& reg) {
     for(auto id : reg.pool<Velocity>().entities()) ids.insert(id);
     for(auto id : reg.pool<Renderable>().entities()) ids.insert(id);
     for(auto id : reg.pool<NavComponent>().entities()) ids.insert(id);
+    for(auto id : reg.pool<BehaviorComponent>().entities()) ids.insert(id);
     for(EntityID id : ids) {
         root["entities"].push_back(Serialize(reg, Entity{const_cast<Registry*>(&reg), id}));
     }

--- a/tests/ecs/TestBehaviorSystem.cpp
+++ b/tests/ecs/TestBehaviorSystem.cpp
@@ -1,0 +1,34 @@
+#include "ecs/BehaviorSystem.h"
+#include "ecs/Registry.h"
+#include <gtest/gtest.h>
+
+using namespace pe::ecs;
+
+TEST(BehaviorSystem, IdleSwitchesToSeek)
+{
+    Registry reg;
+    auto e = reg.create();
+    auto& pos = reg.add<Position>(e.id());
+    auto& beh = reg.add<BehaviorComponent>(e.id());
+    beh.idleDuration = 0.f;
+    beh.target = {1.f, 0.f};
+    BehaviorSystem sys(reg);
+    sys.Update(0.1f);
+    EXPECT_EQ(beh.state, BehaviorState::Seek);
+}
+
+TEST(BehaviorSystem, SeekMovesAndReturnsIdle)
+{
+    Registry reg;
+    auto e = reg.create();
+    auto& pos = reg.add<Position>(e.id());
+    auto& beh = reg.add<BehaviorComponent>(e.id());
+    beh.idleDuration = 0.f;
+    beh.target = {1.f, 0.f};
+    BehaviorSystem sys(reg);
+    sys.Update(0.f); // switch to Seek immediately
+    sys.Update(1.f); // move toward target
+    sys.Update(0.f); // evaluate arrival
+    EXPECT_NEAR(pos.x, 1.f, 0.05f);
+    EXPECT_EQ(beh.state, BehaviorState::Idle);
+}


### PR DESCRIPTION
## Summary
- introduce `BehaviorComponent` and `BehaviorSystem`
- integrate new component into registry and save manager
- document the behaviour system in architecture docs
- add unit tests for behaviour system

## Testing
- `cmake -S . -B build-debug`
- `cmake --build build-debug`
- `ctest -R Behavior --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685ebef30074832484ed9f12e409917b