### PR TITLE
Add release packaging script and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,12 @@ install(TARGETS engine
 
 install(DIRECTORY src/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/promethean FILES_MATCHING PATTERN "*.h")
 
+install(DIRECTORY assets/sample_project
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/promethean)
+
+install(FILES README.md docs/GettingStarted.md
+        DESTINATION ${CMAKE_INSTALL_DOCDIR})
+
 if(TARGET promethean)
     install(TARGETS promethean DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/README.md
+++ b/README.md
@@ -262,3 +262,13 @@ To load a Tiled map at runtime:
 ```bash
 ./promethean --map=path/to/level.tmx
 ```
+
+## Packaging release
+
+Run the helper script to produce a distributable archive for your platform:
+
+```bash
+scripts/release.sh
+```
+
+Packages will be generated in `build-release` and include the sample assets and documentation.

--- a/assets/sample_project/README.txt
+++ b/assets/sample_project/README.txt
@@ -1,0 +1,2 @@
+This directory contains a minimal sample world and assets used for quick testing of Promethean Engine.
+Feel free to replace these with your own game data.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,0 +1,21 @@
+# Getting Started
+
+This short guide helps you build and run Promethean Engine in release mode.
+
+```bash
+# Install dependencies (Ubuntu)
+sudo apt install cmake build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev \
+  libsdl2-mixer-dev libgl1-mesa-dev libglew-dev libglm-dev libtinyxml2-dev libspdlog-dev
+
+# Configure and build
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+Run the engine with the sample assets:
+
+```bash
+./build/bin/promethean --map=assets/sample_project/sample.tmx
+```
+
+The `/assets/sample_project` folder contains demo data you can experiment with.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR=build-release
+
+cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release
+cmake --build "$BUILD_DIR" --target package --parallel
+
+echo "Release packages are available in $BUILD_DIR" 


### PR DESCRIPTION
## Summary
- add `release.sh` to build Release and generate CPack packages
- install sample assets and docs when packaging
- document packaging workflow in README
- provide a short Getting Started guide
- add placeholder sample_project assets

## Testing
- `cmake -B build-release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build-release --target package --parallel`
- `ctest --output-on-failure` *(fails: RuntimeOverlay.AudioSlider_ChangesVolume, AudioEngine.Init, AudioEngine.PlaySound_ChannelsDifferent, AudioEngine.MasterVolume, AudioEngine.NoFileWrites, AudioEngine.EventBusPublished, AudioEngine.StopAll, AudioBus.DefaultState, AudioBus.SetGetVolume, AudioBus.MuteState, AudioBus.FadeOutEmptyBus)*

------
https://chatgpt.com/codex/tasks/task_e_6862f824e3f08324b359b469dece1357