### PR TITLE
Add minimal Lua scripting system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ find_package(spdlog        CONFIG REQUIRED)
 find_package(glm           CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(tinyxml2      CONFIG REQUIRED)
+find_package(Lua REQUIRED)
 
 if(NOT ANDROID)                                     # extensions SDL2 uniquement desktop
     find_package(SDL2_image CONFIG REQUIRED)
@@ -133,6 +134,8 @@ add_library(engine
     src/editor/WorldEditor.cpp         src/editor/WorldEditor.h
     src/editor/EditorUI.cpp            src/editor/EditorUI.h
     src/editor/EditorState.cpp         src/editor/EditorState.h
+    # ── Scripting -----------------------------------------------------------
+    src/scripting/ScriptingManager.cpp src/scripting/ScriptingManager.h
 )
 add_library(Promethean::Engine ALIAS engine)
 
@@ -140,6 +143,7 @@ target_include_directories(engine
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
         $<INSTALL_INTERFACE:include>
+        ${LUA_INCLUDE_DIR}
 )
 
 # --------------------------------------------------------------------
@@ -186,6 +190,7 @@ target_link_libraries(engine
         spdlog::spdlog
         glm::glm
         tinyxml2::tinyxml2
+        ${LUA_LIBRARIES}
         $<$<NOT:$<BOOL:${ANDROID}>>:                 # ⇐ extensions uniquement desktop
             $<$<TARGET_EXISTS:SDL2_image::SDL2_image>:SDL2_image::SDL2_image>
             $<$<NOT:$<TARGET_EXISTS:SDL2_image::SDL2_image>>:SDL2_image::SDL2_image-static>
@@ -311,12 +316,16 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/ecs/TestBehaviorSystem.cpp
         tests/save/TestSaveManager.cpp
         tests/editor/TestWorldEditor.cpp
+        tests/scripting/TestScripting.cpp
     )
 
     file(GLOB TEST_AUDIO_FILES
         ${CMAKE_SOURCE_DIR}/tests/assets/audio/*)
     file(COPY ${TEST_AUDIO_FILES}
         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/assets/audio)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/assets/scripts)
+    file(COPY assets/scripts/test_agent.lua
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/assets/scripts)
 
     if(USE_SDL_STUBS)
         target_sources(engine_tests PRIVATE tests/mocks/SDL_mixer_stubs.cpp)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ git clone https://github.com/Microsoft/vcpkg.git
 
 ---
 
+## 📜 Scripting (Lua)
+
+- Intégration minimale de Lua via `ScriptingManager`
+- API disponible côté script : `create_entity`, `add_position`, `log_info`
+- Exemple de script dans `assets/scripts/test_agent.lua`
+
+---
+
 ## 📦 Compilation Android
 
 - Build via **CMake + Android NDK**

--- a/assets/scripts/test_agent.lua
+++ b/assets/scripts/test_agent.lua
@@ -1,0 +1,7 @@
+function OnStart()
+    local id = create_entity()
+    add_position(id, 5, 10)
+    log_info("spawned entity " .. id)
+end
+
+OnStart()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,3 +79,10 @@ Un éditeur minimal de monde permet de créer rapidement une carte 2D. Il gère
 une tilemap unique modifiable à la souris via une interface rudimentaire.
 L'éditeur peut exporter ou importer la carte au format JSON afin d'être chargé
 par le moteur via `AssetManager`.
+
+## Scripting Lua
+
+Un module `ScriptingManager` charge des scripts Lua externes. Il expose une API
+très simple pour créer des entités et modifier leurs composants depuis un
+script. Les fonctions disponibles sont `create_entity`, `add_position` et
+`log_info`. Un script d'exemple est fourni dans `assets/scripts/test_agent.lua`.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,6 @@
 #include "core/Engine.h"
+#include "ecs/ecs.h"
+#include "scripting/ScriptingManager.h"
 
 #ifndef PROMETHEAN_ANDROID_CI
     #include <spdlog/spdlog.h>
@@ -38,7 +40,13 @@ int main(int argc, char* argv[]) {
         (void)map;
     }
 
+    pe::ecs::Registry registry;
+    pe::scripting::ScriptingManager::Instance().Init(&registry);
+    pe::scripting::ScriptingManager::Instance().RunScript("assets/scripts/test_agent.lua");
+
     engine.Run();
+
+    pe::scripting::ScriptingManager::Instance().Shutdown();
 
     engine.Shutdown();
     return 0;

--- a/src/scripting/ScriptingManager.cpp
+++ b/src/scripting/ScriptingManager.cpp
@@ -1,0 +1,91 @@
+#include "scripting/ScriptingManager.h"
+#include "ecs/Registry.h"
+#include "ecs/Component.h"
+#include "core/LogSystem.h"
+
+extern "C" {
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+}
+
+namespace pe::scripting {
+
+ScriptingManager& ScriptingManager::Instance()
+{
+    static ScriptingManager inst;
+    return inst;
+}
+
+bool ScriptingManager::Init(pe::ecs::Registry* registry)
+{
+    m_registry = registry;
+    m_state = luaL_newstate();
+    if(!m_state)
+        return false;
+    luaL_openlibs(m_state);
+    lua_register(m_state, "create_entity", Lua_CreateEntity);
+    lua_register(m_state, "add_position", Lua_AddPosition);
+    lua_register(m_state, "log_info",     Lua_Log);
+    return true;
+}
+
+void ScriptingManager::Shutdown()
+{
+    if(m_state) {
+        lua_close(m_state);
+        m_state = nullptr;
+    }
+    m_registry = nullptr;
+}
+
+bool ScriptingManager::RunScript(const std::string& file)
+{
+    if(!m_state)
+        return false;
+    m_lastFile = file;
+    if(luaL_dofile(m_state, file.c_str()) != LUA_OK) {
+        LogSystem::Instance().Error("Lua error: {}", lua_tostring(m_state, -1));
+        lua_pop(m_state, 1);
+        return false;
+    }
+    return true;
+}
+
+bool ScriptingManager::ReloadScript(const std::string& file)
+{
+    if(file.empty())
+        return RunScript(m_lastFile);
+    return RunScript(file);
+}
+
+int ScriptingManager::Lua_CreateEntity(lua_State* L)
+{
+    auto* reg = Instance().m_registry;
+    if(!reg)
+        return 0;
+    auto e = reg->create();
+    lua_pushinteger(L, static_cast<lua_Integer>(e.id()));
+    return 1;
+}
+
+int ScriptingManager::Lua_AddPosition(lua_State* L)
+{
+    auto* reg = Instance().m_registry;
+    if(!reg)
+        return 0;
+    pe::ecs::EntityID id = static_cast<pe::ecs::EntityID>(luaL_checkinteger(L, 1));
+    float x = static_cast<float>(luaL_checknumber(L, 2));
+    float y = static_cast<float>(luaL_checknumber(L, 3));
+    reg->add<pe::ecs::Position>(id, pe::ecs::Position{x,y});
+    return 0;
+}
+
+int ScriptingManager::Lua_Log(lua_State* L)
+{
+    const char* msg = luaL_checkstring(L, 1);
+    LogSystem::Instance().Info("{}", msg);
+    return 0;
+}
+
+} // namespace pe::scripting

--- a/src/scripting/ScriptingManager.h
+++ b/src/scripting/ScriptingManager.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <string>
+
+struct lua_State;
+
+namespace pe { namespace ecs { class Registry; struct Position; } }
+
+namespace pe::scripting {
+
+class ScriptingManager {
+public:
+    static ScriptingManager& Instance();
+
+    bool Init(pe::ecs::Registry* registry);
+    void Shutdown();
+
+    bool RunScript(const std::string& file);
+    bool ReloadScript(const std::string& file = "");
+
+    pe::ecs::Registry* registry() const { return m_registry; }
+
+private:
+    static int Lua_CreateEntity(lua_State* L);
+    static int Lua_AddPosition(lua_State* L);
+    static int Lua_Log(lua_State* L);
+
+    lua_State* m_state{nullptr};
+    pe::ecs::Registry* m_registry{nullptr};
+    std::string m_lastFile;
+};
+
+} // namespace pe::scripting

--- a/tests/scripting/TestScripting.cpp
+++ b/tests/scripting/TestScripting.cpp
@@ -1,0 +1,16 @@
+#include "scripting/ScriptingManager.h"
+#include "ecs/ecs.h"
+#include <gtest/gtest.h>
+
+using namespace pe::scripting;
+using namespace pe::ecs;
+
+TEST(Scripting, RunScript_SpawnsEntity)
+{
+    Registry reg;
+    auto& sm = ScriptingManager::Instance();
+    ASSERT_TRUE(sm.Init(&reg));
+    ASSERT_TRUE(sm.RunScript("assets/scripts/test_agent.lua"));
+    sm.Shutdown();
+    EXPECT_EQ(reg.active(), 1u);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -28,6 +28,7 @@
     },
     "glm",
     "tinyxml2",
+    "lua",
     "imgui",
     {
       "name": "gtest",


### PR DESCRIPTION
## Summary
- integrate Lua via vcpkg and CMake
- add `ScriptingManager` with API to run Lua scripts and access ECS
- provide example script and GoogleTest
- run example script at startup
- document scripting support in README and architecture docs

## Testing
- `cmake -S . -B build`
- `cmake --build build -- -j2`
- `cd build && ctest -R Scripting -V`

------
https://chatgpt.com/codex/tasks/task_e_6863b108e89083249d1065247e751d2e