### PR TITLE
Fix cross platform interface includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,12 +139,25 @@ add_library(engine
 )
 add_library(Promethean::Engine ALIAS engine)
 
-target_include_directories(engine
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include>
-        ${LUA_INCLUDE_DIR}
-)
+if(NOT APPLE AND NOT ANDROID)
+    # When building locally, expose the source include directory.
+    # Installed/exported targets must not contain absolute paths.
+    target_include_directories(engine
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+            $<INSTALL_INTERFACE:include>
+        PRIVATE
+            ${LUA_INCLUDE_DIR}
+    )
+else()
+    # On macOS/Android, never leak the source directory in INTERFACE includes.
+    target_include_directories(engine
+        PUBLIC
+            $<INSTALL_INTERFACE:include>
+        PRIVATE
+            ${LUA_INCLUDE_DIR}
+    )
+endif()
 
 # --------------------------------------------------------------------
 # Gestion explicite de SDL2 (core + main) pour éviter les alias manquants

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ git clone https://github.com/Microsoft/vcpkg.git
 ./vcpkg/vcpkg install --x-manifest-root=.
 ```
 
+### Modern CMake include pattern
+
+Les cibles suivent le schéma Modern CMake afin de ne jamais exposer de
+chemins absolus provenant du répertoire source lorsqu'elles sont installées.
+Les en-têtes du moteur sont donc visibles seulement pendant la compilation
+locale via `BUILD_INTERFACE`, puis référencés simplement depuis `include/` une fois
+installés. Sur macOS et Android, ce chemin de source n'est jamais ajouté à
+l'interface publique.
+
+
 ---
 
 ## 🧪 Tests & CI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,13 @@ Promethean est un moteur de jeu 2D C++ basé sur SDL2 + OpenGL, orienté modular
 - `platform/` : code Android/Windows
 - `tests/` : Google Test
 
+### CMake
+
+La génération utilise le pattern Modern CMake : les includes publics sont
+exposés avec `BUILD_INTERFACE` uniquement lors de la compilation locale et
+remplacés par `INSTALL_INTERFACE` une fois le moteur installé. Aucun chemin
+absolu du répertoire source n'apparaît dans les cibles exportées.
+
 ## Principes
 
 - 100 % modulaire


### PR DESCRIPTION
## Summary
- avoid leaking source paths in exported targets
- document modern CMake include pattern in README and architecture docs

## Testing
- `cmake -S . -B build-linux`
- `cmake -S . -B build-android -DANDROID=ON`

------
https://chatgpt.com/codex/tasks/task_e_6863bcac2378832490588a11e115c5f0