### PR TITLE
Fix include path for macOS/Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,25 +139,15 @@ add_library(engine
 )
 add_library(Promethean::Engine ALIAS engine)
 
-if(NOT APPLE AND NOT ANDROID)
-    # When building locally, expose the source include directory.
-    # Installed/exported targets must not contain absolute paths.
-    target_include_directories(engine
-        PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-            $<INSTALL_INTERFACE:include>
-        PRIVATE
-            ${LUA_INCLUDE_DIR}
-    )
-else()
-    # On macOS/Android, never leak the source directory in INTERFACE includes.
-    target_include_directories(engine
-        PUBLIC
-            $<INSTALL_INTERFACE:include>
-        PRIVATE
-            ${LUA_INCLUDE_DIR}
-    )
-endif()
+# Always add the source directory privately for local builds. Only the
+# install interface exposes the public headers.
+target_include_directories(engine
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${LUA_INCLUDE_DIR}
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+)
 
 # --------------------------------------------------------------------
 # Gestion explicite de SDL2 (core + main) pour éviter les alias manquants

--- a/README.md
+++ b/README.md
@@ -80,12 +80,11 @@ git clone https://github.com/Microsoft/vcpkg.git
 
 ### Modern CMake include pattern
 
-Les cibles suivent le schéma Modern CMake afin de ne jamais exposer de
-chemins absolus provenant du répertoire source lorsqu'elles sont installées.
-Les en-têtes du moteur sont donc visibles seulement pendant la compilation
-locale via `BUILD_INTERFACE`, puis référencés simplement depuis `include/` une fois
-installés. Sur macOS et Android, ce chemin de source n'est jamais ajouté à
-l'interface publique.
+Les cibles suivent le schéma Modern CMake afin de n'exposer que les fichiers
+installés. Pendant la compilation locale, le dossier `src/` est ajouté en
+`PRIVATE` pour que tous les modules accèdent aux en-têtes internes, sans jamais
+fuir dans l'interface publique. Une fois installée ou exportée, seule la
+référence `include/` est visible via `INSTALL_INTERFACE`.
 
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,10 +22,11 @@ Promethean est un moteur de jeu 2D C++ basé sur SDL2 + OpenGL, orienté modular
 
 ### CMake
 
-La génération utilise le pattern Modern CMake : les includes publics sont
-exposés avec `BUILD_INTERFACE` uniquement lors de la compilation locale et
-remplacés par `INSTALL_INTERFACE` une fois le moteur installé. Aucun chemin
-absolu du répertoire source n'apparaît dans les cibles exportées.
+La génération suit le pattern Modern CMake. Le dossier `src/` est inclus en
+`PRIVATE` pour la compilation de toutes les plateformes afin que les modules du
+moteur accèdent à leurs en-têtes internes. L'interface publique n'expose que le
+répertoire `include/` via `INSTALL_INTERFACE`, évitant tout chemin absolu dans
+les cibles exportées.
 
 ## Principes
 


### PR DESCRIPTION
## Summary
- add `src/` to engine include directories on all platforms
- document include pattern in README and architecture docs

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_6863dd9811608324ab376fdae26c0e59