### PR TITLE
Fix include paths for main binary and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,9 @@ endif()
 # ====================================================================
 if(NOT ANDROID OR PROMETHEAN_BUILD_EXAMPLES)
     add_executable(promethean src/main.cpp)
+    target_include_directories(promethean PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
     target_link_libraries(promethean PRIVATE Promethean::Engine)
 
     set_target_properties(promethean PROPERTIES
@@ -320,6 +323,10 @@ if(PROMETHEAN_BUILD_TESTS AND NOT ANDROID)
         tests/save/TestSaveManager.cpp
         tests/editor/TestWorldEditor.cpp
         tests/scripting/TestScripting.cpp
+    )
+
+    target_include_directories(engine_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
 
     file(GLOB TEST_AUDIO_FILES

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ installés. Pendant la compilation locale, le dossier `src/` est ajouté en
 fuir dans l'interface publique. Une fois installée ou exportée, seule la
 référence `include/` est visible via `INSTALL_INTERFACE`.
 
+Les exécutables de démonstration et les tests ajoutent eux-mêmes ce chemin via
+`target_include_directories()` afin de pouvoir inclure directement les modules
+du moteur (`core/`, `ecs/`, etc.).
+
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,10 @@ moteur accèdent à leurs en-têtes internes. L'interface publique n'expose que 
 répertoire `include/` via `INSTALL_INTERFACE`, évitant tout chemin absolu dans
 les cibles exportées.
 
+Les exécutables locaux et la suite de tests ajoutent explicitement ce même
+chemin `src/` via `target_include_directories()` pour inclure directement les
+en-têtes internes.
+
 ## Principes
 
 - 100 % modulaire


### PR DESCRIPTION
## Summary
- fix not found headers on Ubuntu/macOS/Windows
- document internal include usage in README and docs

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6865018ea3448324b2224c20bd918b6d