### PR TITLE
Fix vcpkg baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "promethean-engine",
   "version-string": "1.0.0",
   "description": "Minimal 2D engine using SDL2",
+  "builtin-baseline": "031ad89ce6c575df35a8e58707ad2c898446c63e",
   "dependencies": [
     "sdl2",
     {


### PR DESCRIPTION
## Summary
- add builtin baseline to `vcpkg.json`

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_6866d17951bc8324936da55d84f3764b